### PR TITLE
SDK-410 -- Disable Tracking (Part 2)

### DIFF
--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -166,6 +166,14 @@ Branch::closeSession(IRequestCallback *callback) {
 
 void
 Branch::sendEvent(const Event &event, IRequestCallback *callback) {
+    if (getAdvertiserInfo().isTrackingDisabled()) {
+        if (callback != NULL) {
+            callback->onStatus(0, 0, "Requested operation cannot be completed since tracking is disabled");
+            callback->onError(0, 0, "Tracking is disabled");
+        }
+        return;
+    }
+
     getRequestManager()->enqueue(event, callback);
 }
 


### PR DESCRIPTION
## Reference
SDK-410 -- Disable Tracking

## Description
On Android, we have the ability to completely disable tracking.   If this is set, nothing goes out.

### Note
Note that this is Part 2 of limiting / disabling Ad Tracking.

## Testing Instructions
* Sample apps should continue to function.
* Unit tests should all pass
* CircleCI Integration Succeeds

I tested this and showed that if I call disableTracking in the hello sample (not committed that way) we get
```
2019-08-22-19:49:21.407171|Warning|0x7fffb31d4380|HelloCallback.cpp:21[onStatus]|Status for ID 0: (0) Requested operation cannot be completed since tracking is disabled
2019-08-22-19:49:21.407251|Error|0x7fffb31d4380|HelloCallback.cpp:16[onError]|Error for ID 0: (0) Tracking is disabled
```

## Risk Assessment [`LOW`]
Mostly removing code.

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
