### PR TITLE
SDK-503 -- Identity ID should not be persisted

### DIFF
--- a/BranchSDK-Samples/console/example/example.cpp
+++ b/BranchSDK-Samples/console/example/example.cpp
@@ -30,6 +30,7 @@ using namespace BranchIO;
 
 // Configuration File Key for the Branch Credentials
 #define KEY_BRANCH "branch_key"
+#define KEY_LINK "branch_link"
 
 class ExampleApp : public Application, public IRequestCallback
 {
@@ -219,8 +220,10 @@ protected:
     }
 
     void handleSendInstallEvent(const std::string &name, const std::string &value) {
+        auto branch_link = config().getString(KEY_LINK);
+
         cout << "handleSendInstallEvent()" << endl;
-        _branchInstance->openSession("https://hello-branch.app.link/0urbx9YcQR", this);
+        _branchInstance->openSession(branch_link, this);
     }
 
     void handleSendOpenEvent(const std::string &name, const std::string &value) {

--- a/BranchSDK-Samples/console/example/example.json
+++ b/BranchSDK-Samples/console/example/example.json
@@ -1,4 +1,5 @@
 {
-	"branch_key" : "key_live_bcMneVUDd5sM5vD4BzfcbikdwrmnRDA8",
+	"branch_key" : "key_live_efTsR1fbTucbHvX3N5RsOaamDtlPFLap",
+    "branch_link" : "https://uxzce.app.link/L9dmODrcKZ"
 	"debug" : true
 }

--- a/BranchSDK-Samples/console/example/example.properties
+++ b/BranchSDK-Samples/console/example/example.properties
@@ -1,3 +1,4 @@
 # Branch Key
-branch_key : key_live_bcMneVUDd5sM5vD4BzfcbikdwrmnRDA8
+branch_key : key_live_efTsR1fbTucbHvX3N5RsOaamDtlPFLap
+branch_link : https://uxzce.app.link/L9dmODrcKZ
 debug : true

--- a/BranchSDK-Samples/console/hello/helloworld.cpp
+++ b/BranchSDK-Samples/console/hello/helloworld.cpp
@@ -15,14 +15,14 @@ int main(int argc, char *argv[])
     Log::setLevel(Log::Verbose);
     std::cout << "Hello " << BranchIO::Branch::getVersion() << std::endl;
 
-    std::string branchKey;
+    // Branch Key
+   std::string branchKey = "key_live_efTsR1fbTucbHvX3N5RsOaamDtlPFLap";
+
+    // Branch link
+    std::string branchLink;
 
     if (argc > 1) {
-        branchKey = argv[1];
-    }
-    if (branchKey.empty()) {
-        std::cerr << "Missing BranchKey" << std::endl;
-        return -1;
+        branchLink = argv[1];
     }
 
     BranchIO::AppInfo appInfo;
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
     HelloCallback callback;
 
     // Open a Branch Session
-    branch->openSession("https://hello-branch.app.link/0urbx9YcQR", &callback);
+    branch->openSession(branchLink, &callback);
 
     // Send a Branch Standard Event
     BranchIO::StandardEvent testEvent1(BranchIO::StandardEvent::Type::PURCHASE);

--- a/BranchSDK/src/BranchIO/SessionInfo.cpp
+++ b/BranchSDK/src/BranchIO/SessionInfo.cpp
@@ -14,7 +14,6 @@ SessionInfo::SessionInfo() {
      * Load these fields from storage if present.
      */
     load(Defines::JSONKEY_SESSION_FINGERPRINT);
-    load(Defines::JSONKEY_SESSION_IDENTITY);
 }
 
 SessionInfo::~SessionInfo() {
@@ -28,7 +27,6 @@ SessionInfo::setFingerprintId(const std::string &deviceFingerprint) {
 
 SessionInfo&
 SessionInfo::setIdentityId(const std::string &identityId) {
-    save(Defines::JSONKEY_SESSION_IDENTITY, identityId);
     return doAddProperty(Defines::JSONKEY_SESSION_IDENTITY, identityId);
 }
 


### PR DESCRIPTION
## Reference
SDK-503 -- Identity ID should not be persisted
SDK-493 -- Update Samples with production keys

## Description
Per @aaaronlopez we should not be persisting the `identity_id` as a global setting.

Further, @GeneShay asked that the hello application can run "out of the box" without having to pass a key as a parameter on the commandline.  

I also updated the example properties file with the updated key, and added a new property to allow a url to be used in the case of "install".

## Testing Instructions
* Sample apps should continue to function.
* Unit tests should all pass
* CircleCI Integration Succeeds

Note that there is a (now) known issue on Mac where the server will not decode a link that is passed.  I believe this to be a showstopper, however it can be made to work on a Windows box by first clicking the link before running the sample.


## Risk Assessment [`LOW`]
Content Type is pretty low level -- please pay special attention to this.

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
