### PR TITLE
SDK-240 -- Add support for customer_event_alias

### DIFF
--- a/BranchSDK/src/BranchIO/Defines.cpp
+++ b/BranchSDK/src/BranchIO/Defines.cpp
@@ -14,6 +14,7 @@ const char *Defines::JSONKEY_ADTYPE = "ad_type";
 const char *Defines::JSONKEY_AFFILIATION = "affiliation";
 const char *Defines::JSONKEY_COUPON = "coupon";
 const char *Defines::JSONKEY_CURRENCY = "currency";
+const char *Defines::JSONKEY_CUSTOMER_EVENT_ALIAS = "customer_event_alias";
 const char *Defines::JSONKEY_DESCRIPTION = "description";
 const char *Defines::JSONKEY_REVENUE = "revenue";
 const char *Defines::JSONKEY_SEARCHQUERY = "search_query";

--- a/BranchSDK/src/BranchIO/Defines.h
+++ b/BranchSDK/src/BranchIO/Defines.h
@@ -20,6 +20,7 @@ class BRANCHIO_DLL_EXPORT Defines {
     static const char *JSONKEY_AFFILIATION;              ///< Affiliation
     static const char *JSONKEY_COUPON;                   ///< Coupon Code
     static const char *JSONKEY_CURRENCY;                 ///< ISO4217 Currency Code
+    static const char *JSONKEY_CUSTOMER_EVENT_ALIAS;     ///< Customer Event Alias
     static const char *JSONKEY_DESCRIPTION;              ///< Description
     static const char *JSONKEY_REVENUE;                  ///< Revenue
     static const char *JSONKEY_SEARCHQUERY;              ///< Search Query

--- a/BranchSDK/src/BranchIO/Event/Event.cpp
+++ b/BranchSDK/src/BranchIO/Event/Event.cpp
@@ -62,6 +62,11 @@ Event::setCurrency(const CurrencyType &currency) {
 }
 
 Event&
+Event::setCustomerEventAlias(const std::string &alias) {
+    return addEventProperty(Defines::JSONKEY_CUSTOMER_EVENT_ALIAS, alias);
+}
+
+Event&
 Event::setDescription(const std::string &description) {
     return addEventProperty(Defines::JSONKEY_DESCRIPTION, description);
 }

--- a/BranchSDK/src/BranchIO/Event/Event.h
+++ b/BranchSDK/src/BranchIO/Event/Event.h
@@ -59,6 +59,13 @@ class BRANCHIO_DLL_EXPORT Event : public PropertyManager {
     virtual Event& setCurrency(const CurrencyType &currency);
 
     /**
+     * Set the Customer Event Alias with this transaction event.
+     * @param alias Customer Event Alias.
+     * @return This object for chaining builder methods
+     */
+    virtual Event& setCustomerEventAlias(const std::string &alias);
+
+    /**
      * Set description for this transaction event.
      * @param description transaction description
      * @return This object for chaining builder methods

--- a/BranchSDK/test/EventTest.cpp
+++ b/BranchSDK/test/EventTest.cpp
@@ -1,0 +1,39 @@
+#include <BranchIO/Event/StandardEvent.h>
+#include <BranchIO/Request.h>
+
+// Use <gtest/gtest.h> when not using mocks.
+// Otherwise <gmock/gmock.h> also brings in gtest.
+#include <gtest/gtest.h>
+#include <BranchIO/PackagingInfo.h>
+
+using namespace std;
+using namespace BranchIO;
+using namespace testing;
+
+class EventTest : public ::testing::Test
+{
+};
+
+TEST_F(EventTest, TestCreateEvent)
+{
+    PackagingInfo packagingInfo("key_live_xxx");
+    StandardEvent event(StandardEvent::Type::PURCHASE);
+
+    event.setAdType(Event::AdType::NATIVE);
+    event.setAffiliation("My Affiliation");
+    event.setCoupon("My Coupon");
+    event.setCurrency("My CurrencyType");
+    event.setCustomerEventAlias("My Alias");
+    event.setDescription("My Description");
+    event.setRevenue(99.99);
+    event.setSearchQuery("My SearchQuery");
+    event.setShipping(9.99);
+    event.setTax(0.99);
+    event.setTransactionId("My TransactionId");
+    event.addCustomDataProperty("Custom", "My Custom Data Property");
+
+    JSONObject jsonObject;
+    event.package(packagingInfo, jsonObject);
+
+    // cout << "TestCreateEvent: " << jsonObject.stringify() << endl;
+}


### PR DESCRIPTION
## Reference
SDK-240 -- Add support for customer_event_alias

## Description
`customer_event_alias` is a new key/value pair for V2 standard events.

This ticket adds `setCustomerEventAlias()` to the Event class.

## Testing Instructions
* Sample app should compile and run
* New unit test was written to demonstrate usage.

Note that we aren't able to (easily) pull out components of JSON.   For purposes of testing this feature I added a print statement and verified that the new field is in there.

```
{
    "branch_key": "key_live_xxx",
    "custom_data": {
        "Custom": "My Custom Data Property"
    },
    "event_data": {
        "ad_type": "NATIVE",
        "affiliation": "My Affiliation",
        "coupon": "My Coupon",
        "currency": "My CurrencyType",
        "customer_event_alias": "My Alias",
        "description": "My Description",
        "revenue": 99.99,
        "search_query": "My SearchQuery",
        "shipping": 9.99,
        "tax": 0.99,
        "transaction_id": "My TransactionId"
    },
    "name": "PURCHASE",
    "user_data": {
        "device_fingerprint_id": "692367080658056424",
        "limit_ad_tracking": 0,
        "local_ip": "fe80::aede:48ff:fe00:1122%en5",
        "mac_address": "ac:de:48:00:11:22",
        "os": "Darwin",
        "os_version": "17.7.0",
        "sdk": "native",
        "sdk_version": "0.1.0"
    }
}
```

## Risk Assessment [`LOW`]
This is relatively straight forward.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [x] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [x] Mission critical pieces are documented in code and out of code as needed
- [x] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)