### PR TITLE
SDK-601 -- AdvertiserInfo has toXString instead of toString

### DIFF
--- a/BranchSDK/src/BranchIO/AdvertiserInfo.cpp
+++ b/BranchSDK/src/BranchIO/AdvertiserInfo.cpp
@@ -13,9 +13,7 @@ AdvertiserInfo::~AdvertiserInfo() {
 
 AdvertiserInfo&
 AdvertiserInfo::addId(AdIdType type, const std::string &value) {
-    std::string key = stringify(type);
-
-    PropertyManager::addProperty(key.c_str(), value);
+    PropertyManager::addProperty(stringify(type), value);
     return *this;
 }
 
@@ -47,8 +45,8 @@ AdvertiserInfo::isTrackingLimited() const {
     return trackingLimited;
 }
 
-std::string
-AdvertiserInfo::stringify(AdIdType idType) const {
+const char *
+AdvertiserInfo::stringify(AdIdType idType) {
     switch (idType) {
         case IDFA:                      return "idfa";
         case GOOGLE_ADVERTISING_ID:     return "google_advertising_id";

--- a/BranchSDK/src/BranchIO/AdvertiserInfo.cpp
+++ b/BranchSDK/src/BranchIO/AdvertiserInfo.cpp
@@ -13,9 +13,9 @@ AdvertiserInfo::~AdvertiserInfo() {
 
 AdvertiserInfo&
 AdvertiserInfo::addId(AdIdType type, const std::string &value) {
-    const char *key = toXString(type);
+    std::string key = stringify(type);
 
-    PropertyManager::addProperty(key, value);
+    PropertyManager::addProperty(key.c_str(), value);
     return *this;
 }
 
@@ -47,18 +47,18 @@ AdvertiserInfo::isTrackingLimited() const {
     return trackingLimited;
 }
 
-const char *
-AdvertiserInfo::toXString(AdIdType idType) const {
+std::string
+AdvertiserInfo::stringify(AdIdType idType) const {
     switch (idType) {
-        case IDFA:                      return "idfa"; break;
-        case GOOGLE_ADVERTISING_ID:     return "google_advertising_id"; break;
-        case WINDOWS_ADVERTISING_ID:    return "windows_advertising_id"; break;
-        case ROKU_RIDA:                 return "roku_rida"; break;
-        case SAMSUNG_IFA:               return "samsung_ifa"; break;
-        case LG_IFA:                    return "lg_ifa"; break;
-        case PANASONIC_IFA:             return "panasonic_ifa"; break;
-        case PLAYSTATION_IFA:           return "playstation_ifa"; break;
-        case XBOX_MSAI:                 return "xbox_msai"; break;
+        case IDFA:                      return "idfa";
+        case GOOGLE_ADVERTISING_ID:     return "google_advertising_id";
+        case WINDOWS_ADVERTISING_ID:    return "windows_advertising_id";
+        case ROKU_RIDA:                 return "roku_rida";
+        case SAMSUNG_IFA:               return "samsung_ifa";
+        case LG_IFA:                    return "lg_ifa";
+        case PANASONIC_IFA:             return "panasonic_ifa";
+        case PLAYSTATION_IFA:           return "playstation_ifa";
+        case XBOX_MSAI:                 return "xbox_msai";
     }
 
     return "";

--- a/BranchSDK/src/BranchIO/AdvertiserInfo.h
+++ b/BranchSDK/src/BranchIO/AdvertiserInfo.h
@@ -82,7 +82,7 @@ class BRANCHIO_DLL_EXPORT AdvertiserInfo : public PropertyManager {
     bool trackingDisabled;
     bool trackingLimited;
 
-    const char *toXString(AdvertiserInfo::AdIdType idType) const;
+    std::string stringify(AdvertiserInfo::AdIdType idType) const;
 };
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/AdvertiserInfo.h
+++ b/BranchSDK/src/BranchIO/AdvertiserInfo.h
@@ -82,7 +82,7 @@ class BRANCHIO_DLL_EXPORT AdvertiserInfo : public PropertyManager {
     bool trackingDisabled;
     bool trackingLimited;
 
-    std::string stringify(AdvertiserInfo::AdIdType idType) const;
+    static const char *stringify(AdvertiserInfo::AdIdType idType);
 };
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/Defines.cpp
+++ b/BranchSDK/src/BranchIO/Defines.cpp
@@ -74,7 +74,7 @@ const char *PATH_TRACK_STANDARD_EVENT = "v2/event/standard";
 const char *PATH_TRACK_CUSTOM_EVENT = "v2/event/custom";
 
 const std::string
-Defines::toString(APIEndpoint apiEndpoint) {
+Defines::stringify(APIEndpoint apiEndpoint) {
     std::stringstream ss;
     ss << BRANCH_IO_URL_BASE;
 

--- a/BranchSDK/src/BranchIO/Defines.h
+++ b/BranchSDK/src/BranchIO/Defines.h
@@ -99,7 +99,7 @@ class BRANCHIO_DLL_EXPORT Defines {
      * @param endpoint API Endpoint
      * @return a string representation of the endpoint.
      */
-    static const std::string toString(APIEndpoint endpoint);
+    static const std::string stringify(APIEndpoint endpoint);
 
     /**
      * (Internal) Given an Endpoint, determine if it is a V1 or V2 Type

--- a/BranchSDK/src/BranchIO/Event/Event.cpp
+++ b/BranchSDK/src/BranchIO/Event/Event.cpp
@@ -43,7 +43,7 @@ Event::~Event() { }
 
 Event&
 Event::setAdType(Event::AdType adType) {
-    return addEventProperty(Defines::JSONKEY_ADTYPE, toString(adType));
+    return addEventProperty(Defines::JSONKEY_ADTYPE, stringify(adType));
 }
 
 Event&
@@ -134,7 +134,7 @@ const std::string &
 Event::name() const { return mEventName; }
 
 const char *
-Event::toString(Event::AdType adType) {
+Event::stringify(Event::AdType adType) {
     switch (adType) {
         case BANNER:
             return AD_TYPE_BANER;
@@ -154,7 +154,7 @@ Event::toString(Event::AdType adType) {
 
 
 void Event::packageRawEvent(JSONObject &jsonObject) const {
-    jsonObject.parse(stringify());
+    jsonObject.parse(PropertyManager::stringify());
 }
 
 void Event::packageV1Event(IPackagingInfo &packagingInfo, JSONObject &jsonObject) const {

--- a/BranchSDK/src/BranchIO/Event/Event.h
+++ b/BranchSDK/src/BranchIO/Event/Event.h
@@ -172,7 +172,7 @@ class BRANCHIO_DLL_EXPORT Event : public PropertyManager {
  private:
     Event();
 
-    static const char *toString(Event::AdType adType);
+    static const char *stringify(Event::AdType adType);
 
     void packageRawEvent(JSONObject &jsonObject) const;
     void packageV1Event(IPackagingInfo &branch, JSONObject &jsonObject) const;

--- a/BranchSDK/src/BranchIO/Event/StandardEvent.cpp
+++ b/BranchSDK/src/BranchIO/Event/StandardEvent.cpp
@@ -31,10 +31,10 @@ const char *SE_CLICK_AD = "CLICK_AD";
 const char *SE_VIEW_AD = "VIEW_AD";
 
 StandardEvent::StandardEvent(StandardEvent::Type eventType) :
-    Event(Defines::APIEndpoint::TRACK_STANDARD_EVENT, StandardEvent::toString(eventType)) { }
+    Event(Defines::APIEndpoint::TRACK_STANDARD_EVENT, StandardEvent::stringify(eventType)) { }
 
 const char *
-StandardEvent::toString(StandardEvent::Type eventType) {
+StandardEvent::stringify(StandardEvent::Type eventType) {
     switch (eventType) {
         case StandardEvent::ADD_TO_CART:
             return SE_ADD_TO_CART;

--- a/BranchSDK/src/BranchIO/Event/StandardEvent.h
+++ b/BranchSDK/src/BranchIO/Event/StandardEvent.h
@@ -52,7 +52,7 @@ class BRANCHIO_DLL_EXPORT StandardEvent : public Event {
      * @param eventType event type
      * @return a string representation of this class.
      */
-    static const char *toString(StandardEvent::Type eventType);
+    static const char *stringify(StandardEvent::Type eventType);
 
     /**
      * Constructor.

--- a/BranchSDK/src/BranchIO/Request.cpp
+++ b/BranchSDK/src/BranchIO/Request.cpp
@@ -25,7 +25,7 @@ void Request::send(
     IRequestCallback &callback,
     IClientSession *clientSession) {
 
-    URI uri(Defines::toString(api));
+    URI uri(Defines::stringify(api));
     std::string path(uri.getPathAndQuery());
     if (path.empty()) {
         path = "/";


### PR DESCRIPTION
## Reference
SDK-601 -- AdvertiserInfo has toXString instead of toString

## Description
One of the earlier commits introduced a method toXString().

Note that I did some general cleanup around "toString" and "stringify".   In general the semantics going forward should be that "toString()" takes a class and turns it into a string, while "stringify()" takes a constant and turns that into a string.

JSONObject is the exception (revisit) as POCO used stringify at its base.

## Testing Instructions
* Sample apps should compile and run

## Risk Assessment [`LOW`]
This is mostly changing names

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [x] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [x] Mission critical pieces are documented in code and out of code as needed
- [x] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)