### PR TITLE
SDK-610 -- Invalid define

### DIFF
--- a/BranchSDK-Samples/Windows/ColorPicker/ColorPicker.cpp
+++ b/BranchSDK-Samples/Windows/ColorPicker/ColorPicker.cpp
@@ -350,7 +350,7 @@ void createLayout(HWND hwnd)
 
     // Create a share button
     hwndShare = CreateWindowEx(WS_EX_TRANSPARENT, TEXT("Button"), TEXT("Share"),
-        WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON, rect.left, rect.top, 60, 60, hwndMain, (HMENU)ID_SHARECOLOR, (HINSTANCE)GetWindowLong(hwndMain, GWL_HINSTANCE), NULL);
+        WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON, rect.left, rect.top, 60, 60, hwndMain, (HMENU)ID_SHARECOLOR, NULL, NULL);
 
     // Create a simple text view
     hwndStatus = CreateWindowEx(WS_EX_TRANSPARENT, TEXT("Edit"), TEXT(""),


### PR DESCRIPTION
Win64 and Win32 have different defines available.  GWL_HINSTANCE isn't available on Win64 which caused the ColorPicker demo app to break