### PR TITLE
SDK-615 -- Implementation of setIdentity and logout

### DIFF
--- a/BranchSDK-Samples/console/example/example.cpp
+++ b/BranchSDK-Samples/console/example/example.cpp
@@ -156,6 +156,10 @@ protected:
         _menuOptions.addOption(
             Option("7", "7", "Send Multiple Events (async)")
                 .callback(OptionCallback<ExampleApp>(this, &ExampleApp::handleSendMultipleEvents)));
+
+        _menuOptions.addOption(
+            Option("8", "8", "Send Identity Event")
+                    .callback(OptionCallback<ExampleApp>(this, &ExampleApp::handleSendIdentityEvent)));
     }
 
     void handleHelp(const std::string &name, const std::string &value) {
@@ -267,6 +271,12 @@ protected:
         handleSendCustomEvent(name, value);
     }
 
+    void handleSendIdentityEvent(const std::string &name, const std::string &value) {
+        cout << "handleSendIdentityEvent()" << endl;
+        _branchInstance->setIdentity("Kilroy", this);
+    }
+
+
     void displayHelp() {
         HelpFormatter helpFormatter(options());
         helpFormatter.setCommand(commandName());
@@ -299,17 +309,17 @@ protected:
     // Interface IRequestCallback
     virtual void onSuccess(int id, JSONObject jsonResponse) {
         cout << "Callback Success!" << endl;
-        cout << "onSuccess(): " << jsonResponse.stringify() << endl;
+        cout << jsonResponse.stringify() << endl;
     }
 
     // Interface IRequestCallback
     virtual void onError(int id, int error, std::string description) {
-        cout << "Callback Failed..." << endl;
+        cout << "Callback Failed... " << description << endl;
     }
 
     // Interface IRequestCallback
-    virtual void onStatus(int id, int error, std::string descirption) {
-        cout << "Status updated" << endl;
+    virtual void onStatus(int id, int error, std::string description) {
+        cout << "Status updated: " << description << endl;
     }
 
     bool tryProcessChoice(const Option &option, const std::string &choice) {

--- a/BranchSDK-Samples/console/example/example.cpp
+++ b/BranchSDK-Samples/console/example/example.cpp
@@ -160,6 +160,10 @@ protected:
         _menuOptions.addOption(
             Option("8", "8", "Send Identity Event")
                     .callback(OptionCallback<ExampleApp>(this, &ExampleApp::handleSendIdentityEvent)));
+
+        _menuOptions.addOption(
+                Option("9", "9", "Send Logout Event")
+                        .callback(OptionCallback<ExampleApp>(this, &ExampleApp::handleSendLogoutEvent)));
     }
 
     void handleHelp(const std::string &name, const std::string &value) {
@@ -273,9 +277,13 @@ protected:
 
     void handleSendIdentityEvent(const std::string &name, const std::string &value) {
         cout << "handleSendIdentityEvent()" << endl;
-        _branchInstance->setIdentity("Kilroy", this);
+        _branchInstance->setIdentity("Kilroy was here", this);
     }
 
+    void handleSendLogoutEvent(const std::string &name, const std::string &value) {
+        cout << "handleSendLogoutEvent()" << endl;
+        _branchInstance->logout(this);
+    }
 
     void displayHelp() {
         HelpFormatter helpFormatter(options());

--- a/BranchSDK-Samples/console/example/example.cpp
+++ b/BranchSDK-Samples/console/example/example.cpp
@@ -31,6 +31,7 @@ using namespace BranchIO;
 // Configuration File Key for the Branch Credentials
 #define KEY_BRANCH "branch_key"
 #define KEY_LINK "branch_link"
+#define TRACKING_MENU_OPTION "x"
 
 class ExampleApp : public Application, public IRequestCallback {
 public:
@@ -342,17 +343,57 @@ protected:
         return match;
     }
 
+    bool tryProcessVariableOption(const std::string &choice) {
+        bool match = false;
+
+        if (choice.compare(TRACKING_MENU_OPTION) == 0) {
+            bool isDisabled = _branchInstance->getAdvertiserInfo().isTrackingDisabled();
+
+            if (isDisabled) {
+                _branchInstance->getAdvertiserInfo().enableTracking();
+            } else {
+                _branchInstance->getAdvertiserInfo().disableTracking();
+            }
+
+            isDisabled = !isDisabled;
+
+            cout << "Tracking is now " << (isDisabled ? "DISABLED" : "ENABLED") << endl;
+
+            match = true;
+        }
+
+        return match;
+    }
+
     bool processChoice(const std::string &choice) {
         bool processed = false;
         for (OptionSet::Iterator it1 = _menuOptions.begin(); it1 != _menuOptions.end() && !processed; ++it1) {
             processed = tryProcessChoice(*it1, choice);
         }
-        for (OptionSet::Iterator it2 = options().begin(); it2 != options().end() && !processed; ++it2) {
-            processed = tryProcessChoice(*it2, choice);
+
+        if (!processed) {
+            for (OptionSet::Iterator it2 = options().begin(); it2 != options().end() && !processed; ++it2) {
+                processed = tryProcessChoice(*it2, choice);
+            }
+        }
+
+        if (!processed) {
+            processed = tryProcessVariableOption(choice);
         }
 
         return processed;
     }
+
+    void showTrackingMenuOption() {
+        cout << TRACKING_MENU_OPTION << ". ";
+        if (_branchInstance->getAdvertiserInfo().isTrackingDisabled()) {
+            cout << "Enable";
+        } else {
+            cout << "Disable";
+        }
+        cout << " Tracking" << endl;
+    }
+
 
     void runMenu() {
         std::string choice;
@@ -371,6 +412,9 @@ protected:
                 const Option &o = *it2;
                 cout << o.shortName() << ". " << o.description() << endl;
             }
+
+            // Tracking enabled / disabled
+            showTrackingMenuOption();
 
             cout << endl << "Select Option >> ";
             std::getline(std::cin, choice);

--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -6,6 +6,7 @@
 
 #include "BranchIO/DeviceInfo.h"
 #include "BranchIO/Event/Event.h"
+#include "BranchIO/Event/IdentityEvent.h"
 #include "BranchIO/Event/SessionEvent.h"
 #include "BranchIO/IRequestCallback.h"
 #include "BranchIO/Util/Log.h"
@@ -177,6 +178,23 @@ Branch::sendEvent(const Event &event, IRequestCallback *callback) {
     }
 
     getRequestManager()->enqueue(event, callback);
+}
+
+void
+Branch::setIdentity(const std::string& userId, IRequestCallback *callback) {
+    if (getSessionInfo().hasSessionId()) {
+        IdentityLoginEvent event(userId);
+        sendEvent(event, callback);
+    } else {
+        if (callback != NULL) {
+            callback->onError(0, 0, "No Session");
+        }
+    }
+}
+
+void
+Branch::logout(IRequestCallback *callback) {
+    // TODO(andyp): Implement
 }
 
 void

--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -187,7 +187,7 @@ Branch::setIdentity(const std::string& userId, IRequestCallback *callback) {
         sendEvent(event, callback);
     } else {
         if (callback != NULL) {
-            callback->onError(0, 0, "No Session");
+            callback->onError(0, 0, "No Session has been started.");
         }
     }
 }
@@ -199,7 +199,7 @@ Branch::logout(IRequestCallback *callback) {
         sendEvent(event, callback);
     } else {
         if (callback != NULL) {
-            callback->onError(0, 0, "No Session");
+            callback->onError(0, 0, "No Session has been started.");
         }
     }
 }

--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -194,7 +194,14 @@ Branch::setIdentity(const std::string& userId, IRequestCallback *callback) {
 
 void
 Branch::logout(IRequestCallback *callback) {
-    // TODO(andyp): Implement
+    if (getSessionInfo().hasSessionId()) {
+        IdentityLogoutEvent event;
+        sendEvent(event, callback);
+    } else {
+        if (callback != NULL) {
+            callback->onError(0, 0, "No Session");
+        }
+    }
 }
 
 void

--- a/BranchSDK/src/BranchIO/Branch.h
+++ b/BranchSDK/src/BranchIO/Branch.h
@@ -106,6 +106,27 @@ class BRANCHIO_DLL_EXPORT Branch {
      */
     AdvertiserInfo &getAdvertiserInfo();
 
+ public:
+    // User Identity APIs.
+
+    /**
+     * Identifies the current user to the Branch API by supplying a unique identifier
+     * @param userId   A value containing the unique identifier of the user.
+     * @param callback Callback to fire with success or failure notification.
+     */
+    void setIdentity(const std::string& userId, IRequestCallback *callback);
+
+    /**
+     * This method should be called if you know that a different person is about to use the app. For example,
+     * if you allow users to log out and let their friend use the app, you should call this to notify Branch
+     * to create a new user for this device. This will clear the first and latest params, as a new session is created.</p>
+     *
+     * @param callback Callback to fire with success or failure notification.
+     */
+    void logout(IRequestCallback *callback);
+
+
+ private:
     /**
      * Explicitly shut down this Branch instance. Happens automatically
      * in destructor.

--- a/BranchSDK/src/BranchIO/Defines.cpp
+++ b/BranchSDK/src/BranchIO/Defines.cpp
@@ -35,7 +35,6 @@ const char *Defines::JSONKEY_DEVICE_SCREEN_HEIGHT = "screen_height";
 const char *Defines::JSONKEY_DEVICE_SCREEN_WIDTH = "screen_width";
 
 const char *Defines::JSONKEY_APP_IDENTITY = "identity";
-const char *Defines::JSONKEY_APP_IDENTITYID = "identity_id";
 const char *Defines::JSONKEY_APP_DEVELOPER_IDENTITY = "developer_identity";
 const char *Defines::JSONKEY_APP_ENVIRONMENT = "environment";
 const char *Defines::JSONKEY_APP_LAT_V1 = "lat_val";

--- a/BranchSDK/src/BranchIO/Defines.cpp
+++ b/BranchSDK/src/BranchIO/Defines.cpp
@@ -34,6 +34,8 @@ const char *Defines::JSONKEY_DEVICE_SCREEN_DPI = "screen_dpi";
 const char *Defines::JSONKEY_DEVICE_SCREEN_HEIGHT = "screen_height";
 const char *Defines::JSONKEY_DEVICE_SCREEN_WIDTH = "screen_width";
 
+const char *Defines::JSONKEY_APP_IDENTITY = "identity";
+const char *Defines::JSONKEY_APP_IDENTITYID = "identity_id";
 const char *Defines::JSONKEY_APP_DEVELOPER_IDENTITY = "developer_identity";
 const char *Defines::JSONKEY_APP_ENVIRONMENT = "environment";
 const char *Defines::JSONKEY_APP_LAT_V1 = "lat_val";
@@ -145,6 +147,7 @@ Defines::endpointType(APIEndpoint apiEndpoint) {
         case REGISTER_OPEN:
         case REGISTER_CLOSE:
         case REGISTER_VIEW:
+        case IDENTIFY_USER:
         case LOGOUT:
         case URL:
             apiType = V1;
@@ -156,7 +159,6 @@ Defines::endpointType(APIEndpoint apiEndpoint) {
         case GET_CREDITS:
         case GET_CREDIT_HISTORY:
         case GET_REFERRAL_CODE:
-        case IDENTIFY_USER:
         case REDEEM_REWARDS:
         case TRACK_CUSTOM_EVENT:
         case TRACK_STANDARD_EVENT:

--- a/BranchSDK/src/BranchIO/Defines.h
+++ b/BranchSDK/src/BranchIO/Defines.h
@@ -41,7 +41,6 @@ class BRANCHIO_DLL_EXPORT Defines {
     static const char *JSONKEY_DEVICE_SCREEN_WIDTH;      ///< Device Screen Width (pixels)
 
     static const char *JSONKEY_APP_IDENTITY;             ///< User Identity
-    static const char *JSONKEY_APP_IDENTITYID;           ///< User Identity Id
     static const char *JSONKEY_APP_DEVELOPER_IDENTITY;   ///< App Developer Identity
     static const char *JSONKEY_APP_ENVIRONMENT;          ///< App Environment
     static const char *JSONKEY_APP_LAT_V1;               ///< Limit App Tracking, V1

--- a/BranchSDK/src/BranchIO/Defines.h
+++ b/BranchSDK/src/BranchIO/Defines.h
@@ -40,6 +40,8 @@ class BRANCHIO_DLL_EXPORT Defines {
     static const char *JSONKEY_DEVICE_SCREEN_HEIGHT;     ///< Device Screen Height (pixels)
     static const char *JSONKEY_DEVICE_SCREEN_WIDTH;      ///< Device Screen Width (pixels)
 
+    static const char *JSONKEY_APP_IDENTITY;             ///< User Identity
+    static const char *JSONKEY_APP_IDENTITYID;           ///< User Identity Id
     static const char *JSONKEY_APP_DEVELOPER_IDENTITY;   ///< App Developer Identity
     static const char *JSONKEY_APP_ENVIRONMENT;          ///< App Environment
     static const char *JSONKEY_APP_LAT_V1;               ///< Limit App Tracking, V1

--- a/BranchSDK/src/BranchIO/Event/IdentityEvent.h
+++ b/BranchSDK/src/BranchIO/Event/IdentityEvent.h
@@ -11,7 +11,7 @@
 namespace BranchIO {
 
 /**
- * (Internal) User Identity Event
+ * (Internal) User Identity Login Event
  */
 class BRANCHIO_DLL_EXPORT IdentityLoginEvent : public Event {
  public:
@@ -20,12 +20,25 @@ class BRANCHIO_DLL_EXPORT IdentityLoginEvent : public Event {
      * @param identity A value containing the unique identifier of the user
      */
     IdentityLoginEvent(std::string identity) :
-            Event(Defines::APIEndpoint::IDENTIFY_USER, "setIdentity", NULL) {
+            Event(Defines::APIEndpoint::IDENTIFY_USER, "setIdentity") {
 
         Event::addEventProperty(Defines::JSONKEY_APP_IDENTITY, identity);
     }
 };
 
+/**
+ * (Internal) User Identity Logout Event
+ */
+class BRANCHIO_DLL_EXPORT IdentityLogoutEvent : public Event {
+public:
+    /**
+     * Constructor.
+     * @param identity A value containing the unique identifier of the user
+     */
+    explicit IdentityLogoutEvent() :
+            Event(Defines::APIEndpoint::LOGOUT, "logout") {
+    }
+};
 
 }  // namespace BranchIO
 

--- a/BranchSDK/src/BranchIO/Event/IdentityEvent.h
+++ b/BranchSDK/src/BranchIO/Event/IdentityEvent.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2019 Branch Metrics, Inc.
+
+#ifndef BRANCHIO_EVENT_IDENTITYEVENT_H__
+#define BRANCHIO_EVENT_IDENTITYEVENT_H__
+
+#include <string>
+
+#include "BranchIO/Event/Event.h"
+#include "BranchIO/JSONObject.h"
+
+namespace BranchIO {
+
+/**
+ * (Internal) User Identity Event
+ */
+class BRANCHIO_DLL_EXPORT IdentityLoginEvent : public Event {
+ public:
+    /**
+     * Constructor.
+     * @param identity A value containing the unique identifier of the user
+     */
+    IdentityLoginEvent(std::string identity) :
+            Event(Defines::APIEndpoint::IDENTIFY_USER, "setIdentity", NULL) {
+
+        Event::addEventProperty(Defines::JSONKEY_APP_IDENTITY, identity);
+    }
+};
+
+
+}  // namespace BranchIO
+
+#endif  // BRANCHIO_EVENT_IDENTITYEVENT_H__

--- a/BranchSDK/src/BranchIO/Event/SessionEvent.h
+++ b/BranchSDK/src/BranchIO/Event/SessionEvent.h
@@ -19,10 +19,9 @@ class BRANCHIO_DLL_EXPORT SessionEvent : public Event {
      * Constructor.
      * @param apiEndpoint API endpoint
      * @param eventName Event Name
-     * @param jsonPtr pre-filled JSONObject to seed this class.
      */
-    SessionEvent(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr = NULL) :
-        Event(apiEndpoint, eventName, jsonPtr) {}
+    SessionEvent(Defines::APIEndpoint apiEndpoint, const std::string &eventName) :
+        Event(apiEndpoint, eventName) {}
 };
 
 /**
@@ -32,10 +31,9 @@ class BRANCHIO_DLL_EXPORT SessionOpenEvent : public SessionEvent {
  public:
      /**
       * Constructor.
-      * @param jsonPtr pre-filled JSONObject to seed this class.
       */
-    explicit SessionOpenEvent(JSONObject::Ptr jsonPtr = NULL) :
-        SessionEvent(Defines::APIEndpoint::REGISTER_OPEN, "Open", jsonPtr) {}
+    explicit SessionOpenEvent() :
+        SessionEvent(Defines::APIEndpoint::REGISTER_OPEN, "Open") {}
 
     /**
      * Set the Link URL
@@ -57,10 +55,9 @@ class BRANCHIO_DLL_EXPORT SessionViewEvent: public SessionEvent {
  public:
      /**
       * Constructor.
-      * @param jsonPtr pre-filled JSONObject to seed this class.
       */
-    explicit SessionViewEvent(JSONObject::Ptr jsonPtr = NULL) :
-        SessionEvent(Defines::APIEndpoint::REGISTER_VIEW, "View", jsonPtr) {}
+    explicit SessionViewEvent() :
+        SessionEvent(Defines::APIEndpoint::REGISTER_VIEW, "View") {}
 };
 
 /**
@@ -70,10 +67,9 @@ class BRANCHIO_DLL_EXPORT SessionCloseEvent: public SessionEvent {
  public:
      /**
       * Constructor.
-      * @param jsonPtr pre-filled JSONObject to seed this class.
       */
-    explicit SessionCloseEvent(JSONObject::Ptr jsonPtr = NULL) :
-        SessionEvent(Defines::APIEndpoint::REGISTER_CLOSE, "Close", jsonPtr) {}
+    explicit SessionCloseEvent() :
+        SessionEvent(Defines::APIEndpoint::REGISTER_CLOSE, "Close") {}
 };
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/SessionInfo.cpp
+++ b/BranchSDK/src/BranchIO/SessionInfo.cpp
@@ -35,6 +35,11 @@ SessionInfo::setSessionId(const std::string &sessionId) {
     return doAddProperty(Defines::JSONKEY_SESSION_ID, sessionId);
 }
 
+bool
+SessionInfo::hasSessionId() const {
+    return has(Defines::JSONKEY_SESSION_ID);
+}
+
 SessionInfo&
 SessionInfo::doAddProperty(const char *name, const std::string &value) {
     addProperty(name, value);

--- a/BranchSDK/src/BranchIO/SessionInfo.h
+++ b/BranchSDK/src/BranchIO/SessionInfo.h
@@ -41,6 +41,11 @@ class BRANCHIO_DLL_EXPORT SessionInfo : public PropertyManager {
      */
     virtual SessionInfo& setSessionId(const std::string &sessionId);
 
+    /**
+     * @return true if there is a current session.
+     */
+    virtual bool hasSessionId() const;
+
  private:
     static constexpr const char *const StoragePrefix = "session";
 


### PR DESCRIPTION
## Reference
SDK-615 -- Implementation of setIdentity() and logout()

## Description
The C++ SDK needs to be able to identify users uniquely. In other SDKs, this is typically done by `setIdentity()`.

The method `logout()` is typically paired with this.

NOTE that I also added enable/disable tracking to the example app.   This functionality was already in the SDK but wasn't exposed via. the sample.

## Testing Instructions
* Sample app should compile and run

### Using the Example sample to test
While using the Example sample to test it should be noted that `setIdentity()` and `logout()` are -- at this point -- the only APIs that require an active session.   Calling these APIs prior to a session will generate an error callback.

Further, there is a bit of a race condition here -- because the session must *successfully complete* prior to calling setIdentity.

## Risk Assessment [`MEDIUM`]
This is core Branch functionality and should be tested accordingly

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)