### PR TITLE
SDK-630 -- Better conan version management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 # TODO(jdee): Set the version in one place and pass it around.
-project(root VERSION 0.1.0 LANGUAGES CXX)
+project(root VERSION 0.2.0 LANGUAGES CXX)
 
 # Determines handling of RPATH and related variables when building dylibs on Mac.
 # TODO(jdee): Review this. RPATH is an issue on Unix right now.

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ class BranchioConan(ConanFile):
     # ----- Package metadata -----
     name = "BranchIO"
     # TODO(jdee): Set the version in one place and propagate it
-    version = "0.1.0"
+    version = "0.2.0"
     license = "MIT"
     description = "Branch Metrics deep linking and attribution analytics C++ SDK"
     topics = (

--- a/rmake
+++ b/rmake
@@ -71,8 +71,16 @@ then
   exit 1
 fi
 
+# Store the current branch in variable : CurrentBranch
+CurrentBranch=`git rev-parse --abbrev-ref HEAD`
+case "${CurrentBranch}" in
+ 'master') Branch2Use="master" ;;
+ 'Staging') Branch2Use="staging" ;;
+ *)     Branch2Use="testing" ;;
+esac
+
 # Install into the Conan cache
-conan create ../.. branch/testing \
+conan create ../.. branch/${Branch2Use} \
   --json conan-install.json \
   --build outdated \
   --options "*:shared=$BUILD_SHARED_LIBS" \

--- a/rmake
+++ b/rmake
@@ -74,7 +74,7 @@ fi
 # Store the current branch in variable : CurrentBranch
 CurrentBranch=`git rev-parse --abbrev-ref HEAD`
 case "${CurrentBranch}" in
- 'master') Branch2Use="master" ;;
+ 'master') Branch2Use="stable" ;;
  'Staging') Branch2Use="staging" ;;
  *)     Branch2Use="testing" ;;
 esac


### PR DESCRIPTION
## Reference
SDK-630 -- Better conan version management

## Description
We have some things hard coded into our scripts.  Essentially we are always generating version 0.1.0/testing

We'd like to generate new versions like:

* 1.0.0/stable   -- (master branch)
* 1.0.0/staging -- (Staging branch)
* 1.0.0/testing  -- (All other branches)

NOTE that we don't want to go directly to 1.0.0 right now -- we need to go to 0.2.0 until our testing of other features is complete.

## Testing Instructions
On this branch, the `rmake` script should generate version 0.2.0/testing

Once this gets merged to Staging, we can verify that the version becomes 0.2.0/staging
Once this gets merged to master, we can verify that the version becomes 0.2.0/stable

## Risk Assessment [`LOW`]
This is a build script change only

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [x] Conforms to [Style Guides](https://google.github.io/styleguide/cppguide.html)
    - [x] Mission critical pieces are documented in code and out of code as needed.
- [x] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
