### PR TITLE
SDK-632 -- Disable Tracking option does not persist throughout multiple sessions.

### DIFF
--- a/BranchSDK-Samples/Windows/ColorPicker/conanfile.txt
+++ b/BranchSDK-Samples/Windows/ColorPicker/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-BranchIO/0.1.0@branch/testing
+BranchIO/0.2.0@branch/testing
 
 [options]
 # master is the default. Uncomment and modify to use a different branch

--- a/BranchSDK-Samples/console/storagedemo/storagedemo.cpp
+++ b/BranchSDK-Samples/console/storagedemo/storagedemo.cpp
@@ -16,11 +16,12 @@ main(int argc, char **argv) {
 
         storage.setString(keyName, "xyz");
         string value;
-        if (!storage.getString(keyName, value)) {
+        if (!storage.has(keyName)) {
             BRANCH_LOG_E("Value not found");
             return 1;
         }
 
+        value = storage.getString(keyName);
         BRANCH_LOG_I("value for key " << keyName << " is \"" << value << "\"");
 
         storage.remove(keyName);

--- a/BranchSDK-Samples/console/storagedemo/storagedemo.cpp
+++ b/BranchSDK-Samples/console/storagedemo/storagedemo.cpp
@@ -9,7 +9,7 @@ using namespace BranchIO;
 int
 main(int argc, char **argv) {
     try {
-        Storage& storage(Storage::instance());
+        IStorage& storage(Storage::instance());
         storage.setDefaultScope(Storage::User);
 
         const string keyName("session.data");

--- a/BranchSDK-Samples/console/storagedemo/storagedemo.cpp
+++ b/BranchSDK-Samples/console/storagedemo/storagedemo.cpp
@@ -14,9 +14,9 @@ main(int argc, char **argv) {
 
         const string keyName("session.data");
 
-        storage.set(keyName, "xyz");
+        storage.setString(keyName, "xyz");
         string value;
-        if (!storage.get(keyName, value)) {
+        if (!storage.getString(keyName, value)) {
             BRANCH_LOG_E("Value not found");
             return 1;
         }

--- a/BranchSDK/CMakeLists.txt
+++ b/BranchSDK/CMakeLists.txt
@@ -13,6 +13,7 @@ set(BRANCH_SOURCE "")
 # i.e. exclude Unix files from Windows builds, and vice versa.
 # TODO(jdee): Clean this up
 if(${CMAKE_SYSTEM_NAME} MATCHES "Win")
+    add_definitions(-DWIN32)
     foreach(FILE ${ALL_BRANCH_SOURCE})
         if (NOT ${FILE} MATCHES "Unix")
             set(BRANCH_SOURCE ${BRANCH_SOURCE} ${FILE})

--- a/BranchSDK/CMakeLists.txt
+++ b/BranchSDK/CMakeLists.txt
@@ -9,6 +9,8 @@ include_directories(src)
 file(GLOB ALL_BRANCH_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/src/BranchIO/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/BranchIO/**/*.cpp)
 set(BRANCH_SOURCE "")
 
+# Scan all file names looking specifically for "Windows" or "Unix", and exclude from the other type of build.
+# i.e. exclude Unix files from Windows builds, and vice versa.
 # TODO(jdee): Clean this up
 if(${CMAKE_SYSTEM_NAME} MATCHES "Win")
     foreach(FILE ${ALL_BRANCH_SOURCE})

--- a/BranchSDK/src/BranchIO/AdvertiserInfo.cpp
+++ b/BranchSDK/src/BranchIO/AdvertiserInfo.cpp
@@ -6,10 +6,10 @@
 namespace BranchIO {
 
 AdvertiserInfo::AdvertiserInfo() : PropertyManager(), trackingDisabled(false), trackingLimited(false) {
+    trackingDisabled = loadBoolean(AdvertiserStorage, "trackingDisabled", false);
 }
 
-AdvertiserInfo::~AdvertiserInfo() {
-}
+AdvertiserInfo::~AdvertiserInfo() = default;
 
 AdvertiserInfo&
 AdvertiserInfo::addId(AdIdType type, const std::string &value) {
@@ -20,12 +20,14 @@ AdvertiserInfo::addId(AdIdType type, const std::string &value) {
 AdvertiserInfo &
 AdvertiserInfo::disableTracking() {
     trackingDisabled = true;
+    saveBoolean(AdvertiserStorage, "trackingDisabled", true);
     return *this;
 }
 
 AdvertiserInfo &
 AdvertiserInfo::enableTracking() {
     trackingDisabled = false;
+    saveBoolean(AdvertiserStorage, "trackingDisabled", false);
     return *this;
 }
 

--- a/BranchSDK/src/BranchIO/AdvertiserInfo.cpp
+++ b/BranchSDK/src/BranchIO/AdvertiserInfo.cpp
@@ -1,12 +1,17 @@
 // Copyright (c) 2019 Branch Metrics, Inc.
 
 #include "BranchIO/AdvertiserInfo.h"
-#include "Defines.h"
+#include "BranchIO/Defines.h"
+#include "BranchIO/Util/Storage.h"
 
 namespace BranchIO {
 
+static const char *const ADVERTISERSTORAGE = "advertiser";
+static const char *const TRACKING_PREFERENCE_KEY = "trackingDisabled";
+
 AdvertiserInfo::AdvertiserInfo() : PropertyManager(), trackingDisabled(false), trackingLimited(false) {
-    trackingDisabled = loadBoolean(AdvertiserStorage, TRACKING_PREFERENCE_KEY, false);
+    trackingDisabled =
+            Storage::instance().getBoolean(getPath(ADVERTISERSTORAGE, TRACKING_PREFERENCE_KEY));
 }
 
 AdvertiserInfo::~AdvertiserInfo() = default;
@@ -20,14 +25,14 @@ AdvertiserInfo::addId(AdIdType type, const std::string &value) {
 AdvertiserInfo &
 AdvertiserInfo::disableTracking() {
     trackingDisabled = true;
-    saveBoolean(AdvertiserStorage, TRACKING_PREFERENCE_KEY, true);
+    Storage::instance().setBoolean(getPath(ADVERTISERSTORAGE, TRACKING_PREFERENCE_KEY), true);
     return *this;
 }
 
 AdvertiserInfo &
 AdvertiserInfo::enableTracking() {
     trackingDisabled = false;
-    saveBoolean(AdvertiserStorage, TRACKING_PREFERENCE_KEY, false);
+    Storage::instance().setBoolean(getPath(ADVERTISERSTORAGE, TRACKING_PREFERENCE_KEY), false);
     return *this;
 }
 

--- a/BranchSDK/src/BranchIO/AdvertiserInfo.cpp
+++ b/BranchSDK/src/BranchIO/AdvertiserInfo.cpp
@@ -6,7 +6,7 @@
 namespace BranchIO {
 
 AdvertiserInfo::AdvertiserInfo() : PropertyManager(), trackingDisabled(false), trackingLimited(false) {
-    trackingDisabled = loadBoolean(AdvertiserStorage, "trackingDisabled", false);
+    trackingDisabled = loadBoolean(AdvertiserStorage, TRACKING_PREFERENCE_KEY, false);
 }
 
 AdvertiserInfo::~AdvertiserInfo() = default;
@@ -20,14 +20,14 @@ AdvertiserInfo::addId(AdIdType type, const std::string &value) {
 AdvertiserInfo &
 AdvertiserInfo::disableTracking() {
     trackingDisabled = true;
-    saveBoolean(AdvertiserStorage, "trackingDisabled", true);
+    saveBoolean(AdvertiserStorage, TRACKING_PREFERENCE_KEY, true);
     return *this;
 }
 
 AdvertiserInfo &
 AdvertiserInfo::enableTracking() {
     trackingDisabled = false;
-    saveBoolean(AdvertiserStorage, "trackingDisabled", false);
+    saveBoolean(AdvertiserStorage, TRACKING_PREFERENCE_KEY, false);
     return *this;
 }
 

--- a/BranchSDK/src/BranchIO/AdvertiserInfo.h
+++ b/BranchSDK/src/BranchIO/AdvertiserInfo.h
@@ -82,9 +82,6 @@ class BRANCHIO_DLL_EXPORT AdvertiserInfo : public PropertyManager {
     bool trackingDisabled;
     bool trackingLimited;
 
-    static constexpr const char *const AdvertiserStorage = "advertiser";
-    static constexpr const char *const TRACKING_PREFERENCE_KEY = "trackingDisabled";
-
     static const char *stringify(AdvertiserInfo::AdIdType idType);
 };
 

--- a/BranchSDK/src/BranchIO/AdvertiserInfo.h
+++ b/BranchSDK/src/BranchIO/AdvertiserInfo.h
@@ -82,6 +82,7 @@ class BRANCHIO_DLL_EXPORT AdvertiserInfo : public PropertyManager {
     bool trackingDisabled;
     bool trackingLimited;
 
+    static constexpr const char *const AdvertiserStorage = "advertiser";
     static const char *stringify(AdvertiserInfo::AdIdType idType);
 };
 

--- a/BranchSDK/src/BranchIO/AdvertiserInfo.h
+++ b/BranchSDK/src/BranchIO/AdvertiserInfo.h
@@ -83,6 +83,8 @@ class BRANCHIO_DLL_EXPORT AdvertiserInfo : public PropertyManager {
     bool trackingLimited;
 
     static constexpr const char *const AdvertiserStorage = "advertiser";
+    static constexpr const char *const TRACKING_PREFERENCE_KEY = "trackingDisabled";
+
     static const char *stringify(AdvertiserInfo::AdIdType idType);
 };
 

--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -126,11 +126,11 @@ Branch *Branch::create(const std::string &branchKey, AppInfo *pInfo) {
      *
      * Storage::instance().set(key, value, Storage::Host);
      */
-    Storage& storage(Storage::instance());
+    IStorage& storage(Storage::instance());
     storage.setDefaultScope(Storage::User);
 
     // operator new does not return NULL. It throws std::bad_alloc in case of
-    // faliure. no need to check this pointer.
+    // failure. no need to check this pointer.
     if (pInfo) {
         instance->_packagingInfo.getAppInfo().addProperties(pInfo->toJSON());
     }

--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -62,7 +62,7 @@ class SessionCallback : public IRequestCallback {
 
     virtual void onSuccess(int id, JSONObject jsonResponse) {
         // @todo(andyp): Update Branch State
-        if (_context != NULL) {
+        if (_context != nullptr) {
             // If keys exist, we set them on the Session Context.
             // If keys don't exist -- that effectively wipes out the state (on purpose).
             if (jsonResponse.has(Defines::JSONKEY_SESSION_ID)) {
@@ -87,19 +87,19 @@ class SessionCallback : public IRequestCallback {
         }
 
         // Call the original callback
-        if (_parentCallback != NULL) {
+        if (_parentCallback != nullptr) {
             _parentCallback->onSuccess(id, jsonResponse);
         }
     }
 
     virtual void onError(int id, int error, std::string description) {
-        if (_parentCallback != NULL) {
+        if (_parentCallback != nullptr) {
             _parentCallback->onError(id, error, description);
         }
     }
 
     virtual void onStatus(int id, int error, std::string description) {
-        if (_parentCallback != NULL) {
+        if (_parentCallback != nullptr) {
             _parentCallback->onStatus(id, error, description);
         }
     }
@@ -110,7 +110,7 @@ class SessionCallback : public IRequestCallback {
 };
 
 Branch *Branch::create(const std::string &branchKey, AppInfo *pInfo) {
-    Branch *instance = NULL;
+    Branch *instance = nullptr;
 #if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
     instance = new BranchUnix();
 #elif defined(_WIN64) || defined(_WIN32)
@@ -131,7 +131,7 @@ Branch *Branch::create(const std::string &branchKey, AppInfo *pInfo) {
 
     // operator new does not return NULL. It throws std::bad_alloc in case of
     // faliure. no need to check this pointer.
-    if (pInfo != NULL) {
+    if (pInfo != nullptr) {
         instance->_packagingInfo.getAppInfo().addProperties(pInfo->toJSON());
     }
 
@@ -170,7 +170,7 @@ Branch::closeSession(IRequestCallback *callback) {
 void
 Branch::sendEvent(const Event &event, IRequestCallback *callback) {
     if (getAdvertiserInfo().isTrackingDisabled()) {
-        if (callback != NULL) {
+        if (callback != nullptr) {
             callback->onStatus(0, 0, "Requested operation cannot be completed since tracking is disabled");
             callback->onError(0, 0, "Tracking is disabled");
         }
@@ -186,7 +186,7 @@ Branch::setIdentity(const std::string& userId, IRequestCallback *callback) {
         IdentityLoginEvent event(userId);
         sendEvent(event, callback);
     } else {
-        if (callback != NULL) {
+        if (callback != nullptr) {
             callback->onError(0, 0, "No Session has been started.");
         }
     }
@@ -198,7 +198,7 @@ Branch::logout(IRequestCallback *callback) {
         IdentityLogoutEvent event;
         sendEvent(event, callback);
     } else {
-        if (callback != NULL) {
+        if (callback != nullptr) {
             callback->onError(0, 0, "No Session has been started.");
         }
     }

--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -62,7 +62,7 @@ class SessionCallback : public IRequestCallback {
 
     virtual void onSuccess(int id, JSONObject jsonResponse) {
         // @todo(andyp): Update Branch State
-        if (_context != nullptr) {
+        if (_context) {
             // If keys exist, we set them on the Session Context.
             // If keys don't exist -- that effectively wipes out the state (on purpose).
             if (jsonResponse.has(Defines::JSONKEY_SESSION_ID)) {
@@ -87,19 +87,19 @@ class SessionCallback : public IRequestCallback {
         }
 
         // Call the original callback
-        if (_parentCallback != nullptr) {
+        if (_parentCallback) {
             _parentCallback->onSuccess(id, jsonResponse);
         }
     }
 
     virtual void onError(int id, int error, std::string description) {
-        if (_parentCallback != nullptr) {
+        if (_parentCallback) {
             _parentCallback->onError(id, error, description);
         }
     }
 
     virtual void onStatus(int id, int error, std::string description) {
-        if (_parentCallback != nullptr) {
+        if (_parentCallback) {
             _parentCallback->onStatus(id, error, description);
         }
     }
@@ -131,7 +131,7 @@ Branch *Branch::create(const std::string &branchKey, AppInfo *pInfo) {
 
     // operator new does not return NULL. It throws std::bad_alloc in case of
     // faliure. no need to check this pointer.
-    if (pInfo != nullptr) {
+    if (pInfo) {
         instance->_packagingInfo.getAppInfo().addProperties(pInfo->toJSON());
     }
 
@@ -170,7 +170,7 @@ Branch::closeSession(IRequestCallback *callback) {
 void
 Branch::sendEvent(const Event &event, IRequestCallback *callback) {
     if (getAdvertiserInfo().isTrackingDisabled()) {
-        if (callback != nullptr) {
+        if (callback) {
             callback->onStatus(0, 0, "Requested operation cannot be completed since tracking is disabled");
             callback->onError(0, 0, "Tracking is disabled");
         }
@@ -186,7 +186,7 @@ Branch::setIdentity(const std::string& userId, IRequestCallback *callback) {
         IdentityLoginEvent event(userId);
         sendEvent(event, callback);
     } else {
-        if (callback != nullptr) {
+        if (callback) {
             callback->onError(0, 0, "No Session has been started.");
         }
     }
@@ -198,7 +198,7 @@ Branch::logout(IRequestCallback *callback) {
         IdentityLogoutEvent event;
         sendEvent(event, callback);
     } else {
-        if (callback != nullptr) {
+        if (callback) {
             callback->onError(0, 0, "No Session has been started.");
         }
     }

--- a/BranchSDK/src/BranchIO/Branch.h
+++ b/BranchSDK/src/BranchIO/Branch.h
@@ -55,13 +55,13 @@ class BRANCHIO_DLL_EXPORT Branch {
      * @param linkUrl Referring link, or an empty string if none.
      * @param callback Callback to fire with success or failure notification.
      */
-    virtual void openSession(const std::string &linkUrl = "", IRequestCallback *callback = NULL);
+    virtual void openSession(const std::string &linkUrl = "", IRequestCallback *callback = nullptr);
 
     /**
      * Close a Branch Session.
      * @param callback Callback to fire with success or failure notification.
      */
-    virtual void closeSession(IRequestCallback *callback = NULL);
+    virtual void closeSession(IRequestCallback *callback = nullptr);
 
     /**
      * Send an event to Branch.

--- a/BranchSDK/src/BranchIO/Event/Event.cpp
+++ b/BranchSDK/src/BranchIO/Event/Event.cpp
@@ -29,9 +29,9 @@ const char *AD_TYPE_NATIVE = "NATIVE";
 Event::Event(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr) :
     mAPIEndpoint(apiEndpoint),
     mEventName(eventName),
-    mCustomData(NULL) {
+    mCustomData(nullptr) {
 
-    if (jsonPtr.get() != NULL) {
+    if (jsonPtr.get() != nullptr) {
         // Copy the key/values
         for (JSONObject::ConstIterator it = jsonPtr->begin(); it != jsonPtr->end(); ++it) {
             set(it->first, it->second);

--- a/BranchSDK/src/BranchIO/Event/Event.cpp
+++ b/BranchSDK/src/BranchIO/Event/Event.cpp
@@ -31,7 +31,7 @@ Event::Event(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSO
     mEventName(eventName),
     mCustomData(nullptr) {
 
-    if (jsonPtr.get() != nullptr) {
+    if (jsonPtr.get()) {
         // Copy the key/values
         for (JSONObject::ConstIterator it = jsonPtr->begin(); it != jsonPtr->end(); ++it) {
             set(it->first, it->second);

--- a/BranchSDK/src/BranchIO/Event/Event.h
+++ b/BranchSDK/src/BranchIO/Event/Event.h
@@ -151,7 +151,7 @@ class BRANCHIO_DLL_EXPORT Event : public PropertyManager {
      * @param eventName The "Name" of the event
      * @param jsonPtr Base JSON to start with
      */
-    Event(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr = NULL);
+    Event(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr = nullptr);
 
     /**
      * Add a Raw Event Property Name and Value

--- a/BranchSDK/src/BranchIO/Event/IdentityEvent.h
+++ b/BranchSDK/src/BranchIO/Event/IdentityEvent.h
@@ -33,7 +33,6 @@ class BRANCHIO_DLL_EXPORT IdentityLogoutEvent : public Event {
 public:
     /**
      * Constructor.
-     * @param identity A value containing the unique identifier of the user
      */
     explicit IdentityLogoutEvent() :
             Event(Defines::APIEndpoint::LOGOUT, "logout") {

--- a/BranchSDK/src/BranchIO/PropertyManager.cpp
+++ b/BranchSDK/src/BranchIO/PropertyManager.cpp
@@ -81,49 +81,6 @@ PropertyManager::clear() {
     return *this;
 }
 
-std::string
-PropertyManager::getStoragePath(const char *path, const char* key) const {
-    std::string storagePath;
-    if (path && *path != 0) {
-        storagePath += path;
-        storagePath += ".";
-    }
-    storagePath += key;
-
-    return storagePath;
-}
-
-std::string
-PropertyManager::loadString(const char *path, const char* key, const std::string &defValue) {
-    std::string value(defValue);
-    if (Storage::instance().getString(getStoragePath(path, key), value)) {
-        addProperty(key, value);
-    }
-
-    return value;
-}
-
-void
-PropertyManager::saveString(const char *path, const char *key, const std::string &value) {
-    Storage::instance().setString(getStoragePath(path, key), value);
-}
-
-bool
-PropertyManager::loadBoolean(const char *path, const char* key, bool defValue) {
-    bool value = defValue;
-    bool result = Storage::instance().getBoolean(getStoragePath(path, key), value);
-    if (result) {
-        addProperty(key, value);
-    }
-
-    return value;
-}
-
-void
-PropertyManager::saveBoolean(const char *path, const char *key, bool value) {
-    Storage::instance().setBoolean(getStoragePath(path, key), value);
-}
-
 bool
 PropertyManager::has(const char *name) const {
     Mutex::ScopedLock _l(_mutex);
@@ -153,5 +110,17 @@ PropertyManager::toJSON() const {
     Mutex::ScopedLock _l(_mutex);
     return *this;
 }
+
+std::string
+PropertyManager::getPath(const std::string& base, const std::string &key)  {
+    std::string storagePath(base);
+    if (!base.empty()) {
+        storagePath += ".";
+    }
+    storagePath += key;
+
+    return storagePath;
+}
+
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/PropertyManager.cpp
+++ b/BranchSDK/src/BranchIO/PropertyManager.cpp
@@ -84,7 +84,7 @@ PropertyManager::clear() {
 std::string
 PropertyManager::getStoragePath(const char *path, const char* key) const {
     std::string storagePath;
-    if (path != nullptr && *path != 0) {
+    if (path && *path != 0) {
         storagePath += path;
         storagePath += ".";
     }

--- a/BranchSDK/src/BranchIO/PropertyManager.cpp
+++ b/BranchSDK/src/BranchIO/PropertyManager.cpp
@@ -2,6 +2,7 @@
 
 #include "BranchIO/PropertyManager.h"
 #include "BranchIO/JSONObject.h"
+#include "BranchIO/Util/Storage.h"
 
 using namespace Poco;
 
@@ -20,11 +21,10 @@ PropertyManager::PropertyManager(const PropertyManager &other) :
 
 PropertyManager&
 PropertyManager::operator=(const PropertyManager& other) {
-    return static_cast<PropertyManager&>(JSONObject::operator=(other));
+    return dynamic_cast<PropertyManager&>(JSONObject::operator=(other));
 }
 
-PropertyManager::~PropertyManager() {
-}
+PropertyManager::~PropertyManager() = default;
 
 PropertyManager&
 PropertyManager::addProperty(const char *name, const std::string &value) {
@@ -79,6 +79,49 @@ PropertyManager::clear() {
 
     JSONObject::clear();
     return *this;
+}
+
+std::string
+PropertyManager::getStoragePath(const char *path, const char* key) const {
+    std::string storagePath;
+    if (path != nullptr && *path != 0) {
+        storagePath += path;
+        storagePath += ".";
+    }
+    storagePath += key;
+
+    return storagePath;
+}
+
+std::string
+PropertyManager::loadString(const char *path, const char* key, const std::string &defValue) {
+    std::string value(defValue);
+    if (Storage::instance().getString(getStoragePath(path, key), value)) {
+        addProperty(key, value);
+    }
+
+    return value;
+}
+
+void
+PropertyManager::saveString(const char *path, const char *key, const std::string &value) {
+    Storage::instance().setString(getStoragePath(path, key), value);
+}
+
+bool
+PropertyManager::loadBoolean(const char *path, const char* key, bool defValue) {
+    bool value = defValue;
+    bool result = Storage::instance().getBoolean(getStoragePath(path, key), value);
+    if (result) {
+        addProperty(key, value);
+    }
+
+    return value;
+}
+
+void
+PropertyManager::saveBoolean(const char *path, const char *key, bool value) {
+    Storage::instance().setBoolean(getStoragePath(path, key), value);
 }
 
 bool

--- a/BranchSDK/src/BranchIO/PropertyManager.h
+++ b/BranchSDK/src/BranchIO/PropertyManager.h
@@ -128,6 +128,11 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
      */
     virtual bool has(const char *name) const;
 
+    /**
+     * @return true when the group is empty.
+     */
+    virtual bool isEmpty() const;
+
  protected:
     /**
      * Generate a path suitable for use as a complex key.
@@ -137,11 +142,6 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
      * @return a string combination of the base and key
      */
     static std::string getPath(const std::string& base, const std::string &key);
-
-    /**
-     * @return true when the group is empty.
-     */
-    virtual bool isEmpty() const;
 
  private:
     std::string getStoragePath(const char *path, const char* key) const;

--- a/BranchSDK/src/BranchIO/PropertyManager.h
+++ b/BranchSDK/src/BranchIO/PropertyManager.h
@@ -111,44 +111,20 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
     std::string getStringProperty(const char *name);
 
     /**
-     * Load a string property from storage.
-     * @param path Path from which this key will be loaded
-     * @param key Key to load
-     * @param defValue Default value if not found
-     * @return String from storage, or default value if not found.
-     */
-    std::string loadString(const char *path, const char* key, const std::string &defValue);
-
-    /**
-     * Save a property to storage.
-     * @param path Path to which this key will be saved
-     * @param key Key name
-     * @param value Key value
-     */
-    void saveString(const char *path, const char *key, const std::string &value);
-
-    /**
-     * Load a string property from storage.
-     * @param path Path from which this key will be loaded
-     * @param key Key to load
-     * @param defValue bool value from storage, or default value if not found.
-     * @return true if the value was found
-     */
-    bool loadBoolean(const char *path, const char* key, bool defValue);
-
-    /**
-     * Save a property to storage.
-     * @param path Path to which this key will be saved
-     * @param key Key name
-     * @param value Key value
-     */
-    void saveBoolean(const char *path, const char *key, bool value);
-
-    /**
      * @param name Key Value
      * @return true when the given property exists
      */
     virtual bool has(const char *name) const;
+
+ protected:
+    /**
+     * Generate a path suitable for use as a complex key.
+     * For example getPath("session", "state") might return session.state
+     * @param base Base of the path
+     * @param key Key
+     * @return a string combination of the base and key
+     */
+    static std::string getPath(const std::string& base, const std::string &key);
 
  private:
     std::string getStoragePath(const char *path, const char* key) const;

--- a/BranchSDK/src/BranchIO/PropertyManager.h
+++ b/BranchSDK/src/BranchIO/PropertyManager.h
@@ -23,6 +23,11 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
     PropertyManager();
 
     /**
+     * Destructor.
+     */
+    virtual ~PropertyManager();
+
+    /**
      * Constructor.
      * @param jsonObject pre-filled JSONObject to seed this class.
      */
@@ -40,8 +45,6 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
      * @return *this
      */
     PropertyManager& operator=(const PropertyManager& other);
-
-    virtual ~PropertyManager();
 
     /**
      * @return this object as a string
@@ -108,12 +111,47 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
     std::string getStringProperty(const char *name);
 
     /**
+     * Load a string property from storage.
+     * @param path Path from which this key will be loaded
+     * @param key Key to load
+     * @param defValue Default value if not found
+     * @return String from storage, or default value if not found.
+     */
+    std::string loadString(const char *path, const char* key, const std::string &defValue);
+
+    /**
+     * Save a property to storage.
+     * @param path Path to which this key will be saved
+     * @param key Key name
+     * @param value Key value
+     */
+    void saveString(const char *path, const char *key, const std::string &value);
+
+    /**
+     * Load a string property from storage.
+     * @param path Path from which this key will be loaded
+     * @param key Key to load
+     * @param defValue bool value from storage, or default value if not found.
+     * @return true if the value was found
+     */
+    bool loadBoolean(const char *path, const char* key, bool defValue);
+
+    /**
+     * Save a property to storage.
+     * @param path Path to which this key will be saved
+     * @param key Key name
+     * @param value Key value
+     */
+    void saveBoolean(const char *path, const char *key, bool value);
+
+    /**
      * @param name Key Value
      * @return true when the given property exists
      */
     virtual bool has(const char *name) const;
 
  private:
+    std::string getStoragePath(const char *path, const char* key) const;
     mutable Poco::Mutex _mutex;
 };
 

--- a/BranchSDK/src/BranchIO/SessionInfo.cpp
+++ b/BranchSDK/src/BranchIO/SessionInfo.cpp
@@ -2,21 +2,29 @@
 
 #include "BranchIO/SessionInfo.h"
 #include "BranchIO/Defines.h"
+#include "BranchIO/Util/Storage.h"
 
 using std::string;
 
 namespace BranchIO {
 
+const char *const SESSIONSTORAGE = "session";
+
 SessionInfo::SessionInfo() {
     // Load these fields from storage if present.
-    loadString(SessionStorage, Defines::JSONKEY_SESSION_FINGERPRINT, "");
+    std::string deviceFingerprint =
+            Storage::instance().getString(getPath(SESSIONSTORAGE, Defines::JSONKEY_SESSION_FINGERPRINT));
+
+    if (!deviceFingerprint.empty()) {
+        doAddProperty(Defines::JSONKEY_SESSION_FINGERPRINT, deviceFingerprint);
+    }
 }
 
 SessionInfo::~SessionInfo() = default;
 
 SessionInfo&
 SessionInfo::setFingerprintId(const std::string &deviceFingerprint) {
-    saveString(SessionStorage, Defines::JSONKEY_SESSION_FINGERPRINT, deviceFingerprint);
+    Storage::instance().setString(getPath(SESSIONSTORAGE, Defines::JSONKEY_SESSION_FINGERPRINT), deviceFingerprint);
     return doAddProperty(Defines::JSONKEY_SESSION_FINGERPRINT, deviceFingerprint);
 }
 

--- a/BranchSDK/src/BranchIO/SessionInfo.cpp
+++ b/BranchSDK/src/BranchIO/SessionInfo.cpp
@@ -1,27 +1,22 @@
 // Copyright (c) 2019 Branch Metrics, Inc.
 
 #include "BranchIO/SessionInfo.h"
-
 #include "BranchIO/Defines.h"
-#include "BranchIO/Util/Storage.h"
 
 using std::string;
 
 namespace BranchIO {
 
 SessionInfo::SessionInfo() {
-    /**
-     * Load these fields from storage if present.
-     */
-    load(Defines::JSONKEY_SESSION_FINGERPRINT);
+    // Load these fields from storage if present.
+    loadString(SessionStorage, Defines::JSONKEY_SESSION_FINGERPRINT, "");
 }
 
-SessionInfo::~SessionInfo() {
-}
+SessionInfo::~SessionInfo() = default;
 
 SessionInfo&
 SessionInfo::setFingerprintId(const std::string &deviceFingerprint) {
-    save(Defines::JSONKEY_SESSION_FINGERPRINT, deviceFingerprint);
+    saveString(SessionStorage, Defines::JSONKEY_SESSION_FINGERPRINT, deviceFingerprint);
     return doAddProperty(Defines::JSONKEY_SESSION_FINGERPRINT, deviceFingerprint);
 }
 
@@ -44,29 +39,6 @@ SessionInfo&
 SessionInfo::doAddProperty(const char *name, const std::string &value) {
     addProperty(name, value);
     return *this;
-}
-
-std::string
-SessionInfo::getStoragePath(const char* key) {
-    string storagePath(StoragePrefix);
-    storagePath += ".";
-    storagePath += key;
-    return storagePath;
-}
-
-void
-SessionInfo::load(const char* key) {
-    string value;
-
-    string storagePath(getStoragePath(key));
-    if (Storage::instance().get(storagePath, value)) {
-        addProperty(key, value);
-    }
-}
-
-void
-SessionInfo::save(const char *key, const std::string &value) {
-    Storage::instance().set(getStoragePath(key), value);
 }
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/SessionInfo.h
+++ b/BranchSDK/src/BranchIO/SessionInfo.h
@@ -47,13 +47,7 @@ class BRANCHIO_DLL_EXPORT SessionInfo : public PropertyManager {
     virtual bool hasSessionId() const;
 
  private:
-    static constexpr const char *const SessionStorage = "session";
-
-//    static std::string getStoragePath(const char *key);
     virtual SessionInfo& doAddProperty(const char *name, const std::string &value);
-
-//    void load(const char* key);
-//    void save(const char *key, const std::string &value);
 };
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/SessionInfo.h
+++ b/BranchSDK/src/BranchIO/SessionInfo.h
@@ -47,13 +47,13 @@ class BRANCHIO_DLL_EXPORT SessionInfo : public PropertyManager {
     virtual bool hasSessionId() const;
 
  private:
-    static constexpr const char *const StoragePrefix = "session";
+    static constexpr const char *const SessionStorage = "session";
 
-    static std::string getStoragePath(const char *key);
+//    static std::string getStoragePath(const char *key);
     virtual SessionInfo& doAddProperty(const char *name, const std::string &value);
 
-    void load(const char* key);
-    void save(const char *key, const std::string &value);
+//    void load(const char* key);
+//    void save(const char *key, const std::string &value);
 };
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/Util/IStorage.h
+++ b/BranchSDK/src/BranchIO/Util/IStorage.h
@@ -55,7 +55,7 @@ struct IStorage {
      * @param scope the scope for this key (optional if default scope set)
      * @return true if found, false otherwise
      */
-    virtual bool get(const std::string& key, std::string& value, Scope scope = Default) const = 0;
+    virtual bool getString(const std::string& key, std::string& value, Scope scope = Default) const = 0;
 
     /**
      * Set a new value for the specified key and scope (or default scope)
@@ -64,7 +64,25 @@ struct IStorage {
      * @param scope the scope for this key (optional if default scope set)
      * @return *this
      */
-    virtual IStorage& set(const std::string& key, const std::string& value, Scope scope = Default) = 0;
+    virtual IStorage& setString(const std::string& key, const std::string& value, Scope scope = Default) = 0;
+
+    /**
+     * Get the current boolean value of a key, if any
+     * @param key a key to retrieve
+     * @param value a writable bool in which to store the value if found
+     * @param scope the scope for this key (optional if default scope set)
+     * @return true if found, false otherwise
+     */
+    virtual bool getBoolean(const std::string& key, bool& value, Scope scope = Default) const = 0;
+
+    /**
+     * Set a new value for the specified key and scope (or default scope)
+     * @param key a key to set
+     * @param value a new value for the specified key
+     * @param scope the scope for this key (optional if default scope set)
+     * @return *this
+     */
+    virtual IStorage& setBoolean(const std::string& key, bool value, Scope scope = Default) = 0;
 
     /**
      * Remove a key and its corresponding value (if any) for the specified scope or default scope

--- a/BranchSDK/src/BranchIO/Util/IStorage.h
+++ b/BranchSDK/src/BranchIO/Util/IStorage.h
@@ -49,13 +49,13 @@ struct IStorage {
     virtual bool has(const std::string& key, Scope scope = Default) const = 0;
 
     /**
-     * Get the current value of a key, if any
+     * Get the current value of a key.  If not found, return the defaultValue.
      * @param key a key to retrieve
-     * @param value a writable string in which to store the value if found
+     * @param defaultValue a string to use if the key is not found
      * @param scope the scope for this key (optional if default scope set)
-     * @return true if found, false otherwise
+     * @return the value of the key if found, the defaultValue otherwise
      */
-    virtual bool getString(const std::string& key, std::string& value, Scope scope = Default) const = 0;
+    virtual std::string getString(const std::string& key, const std::string& defaultValue = "", Scope scope = Default) const = 0;
 
     /**
      * Set a new value for the specified key and scope (or default scope)
@@ -67,13 +67,13 @@ struct IStorage {
     virtual IStorage& setString(const std::string& key, const std::string& value, Scope scope = Default) = 0;
 
     /**
-     * Get the current boolean value of a key, if any
+     * Get the current value of a key.  If not found, return the defaultValue.
      * @param key a key to retrieve
-     * @param value a writable bool in which to store the value if found
+     * @param defaultValue a bool to use if the key is not found
      * @param scope the scope for this key (optional if default scope set)
-     * @return true if found, false otherwise
+     * @return the value of the key if found, the defaultValue otherwise
      */
-    virtual bool getBoolean(const std::string& key, bool& value, Scope scope = Default) const = 0;
+    virtual bool getBoolean(const std::string& key, bool defaultValue = false, Scope scope = Default) const = 0;
 
     /**
      * Set a new value for the specified key and scope (or default scope)

--- a/BranchSDK/src/BranchIO/Util/Log.cpp
+++ b/BranchSDK/src/BranchIO/Util/Log.cpp
@@ -240,7 +240,7 @@ Log::getDefaultLogLevel() {
 #endif
             );  // NOLINT(whitespace/parens)
 
-    if (envValue == nullptr) return DefaultLevel;
+    if (!envValue) return DefaultLevel;
 
     try {
         Level level;
@@ -259,7 +259,7 @@ Log::getDefaultLogLevel() {
 std::string
 Log::getDefaultLogFile() {
     const char* const envValue(getenv("BRANCHIO_LOG_FILE"));
-    if (envValue == nullptr) return string();
+    if (!envValue) return string();
     return envValue;
 }
 

--- a/BranchSDK/src/BranchIO/Util/Log.h
+++ b/BranchSDK/src/BranchIO/Util/Log.h
@@ -55,7 +55,7 @@ class BRANCHIO_DLL_EXPORT Log {
      * @param file (optional) the file from which the message was logged (set by BRANCH_LOG_E macro)
      * @param line (optional) the line from which the message was logged (set by BRANCH_LOG_E macro)
      */
-    static void e(const std::string& message, const char* func = NULL, const char* file = NULL, int line = 0) {
+    static void e(const std::string& message, const char* func = nullptr, const char* file = nullptr, int line = 0) {
         instance().error(message, func, file, line);
     }
 
@@ -66,7 +66,7 @@ class BRANCHIO_DLL_EXPORT Log {
      * @param file (optional) the file from which the message was logged (set by BRANCH_LOG_W macro)
      * @param line (optional) the line from which the message was logged (set by BRANCH_LOG_W macro)
      */
-    static void w(const std::string& message, const char* func = NULL, const char* file = NULL, int line = 0) {
+    static void w(const std::string& message, const char* func = nullptr, const char* file = nullptr, int line = 0) {
         instance().warning(message, func, file, line);
     }
 
@@ -77,7 +77,7 @@ class BRANCHIO_DLL_EXPORT Log {
      * @param file (optional) the file from which the message was logged (set by BRANCH_LOG_I macro)
      * @param line (optional) the line from which the message was logged (set by BRANCH_LOG_I macro)
      */
-    static void i(const std::string& message, const char* func = NULL, const char* file = NULL, int line = 0) {
+    static void i(const std::string& message, const char* func = nullptr, const char* file = nullptr, int line = 0) {
         instance().info(message, func, file, line);
     }
 
@@ -88,7 +88,7 @@ class BRANCHIO_DLL_EXPORT Log {
      * @param file (optional) the file from which the message was logged (set by BRANCH_LOG_D macro)
      * @param line (optional) the line from which the message was logged (set by BRANCH_LOG_D macro)
      */
-    static void d(const std::string& message, const char* func = NULL, const char* file = NULL, int line = 0) {
+    static void d(const std::string& message, const char* func = nullptr, const char* file = nullptr, int line = 0) {
         instance().debug(message, func, file, line);
     }
 
@@ -99,7 +99,7 @@ class BRANCHIO_DLL_EXPORT Log {
      * @param file (optional) the file from which the message was logged (set by BRANCH_LOG_V macro)
      * @param line (optional) the line from which the message was logged (set by BRANCH_LOG_V macro)
      */
-    static void v(const std::string& message, const char* func = NULL, const char* file = NULL, int line = 0) {
+    static void v(const std::string& message, const char* func = nullptr, const char* file = nullptr, int line = 0) {
         instance().verbose(message, func, file, line);
     }
 

--- a/BranchSDK/src/BranchIO/Util/RequestManager.cpp
+++ b/BranchSDK/src/BranchIO/Util/RequestManager.cpp
@@ -13,11 +13,11 @@ using namespace Poco;
 namespace BranchIO {
 
 RequestManager::RequestManager(IPackagingInfo& packagingInfo, IClientSession *clientSession) :
-    _defaultCallback(NULL),
+    _defaultCallback(nullptr),
     _packagingInfo(&packagingInfo),
     _clientSession(clientSession),
     _shuttingDown(false),
-    _currentRequest(NULL) {
+    _currentRequest(nullptr) {
 }
 
 RequestManager::~RequestManager() {
@@ -111,7 +111,7 @@ void RequestManager::run() {
 
             setCurrentRequest(&requestTask->getRequest());
             task->runTask();
-            setCurrentRequest(NULL);
+            setCurrentRequest(nullptr);
         }
     }
     catch (Poco::Exception& e) {
@@ -154,7 +154,7 @@ RequestManager::RequestTask::runTask() {
         APIClientSession clientSession(BRANCH_IO_URL_BASE);
         _manager.setClientSession(&clientSession);
         _request.send(_event.getAPIEndpoint(), payload, *_callback, &clientSession);
-        _manager.setClientSession(NULL);
+        _manager.setClientSession(nullptr);
     }
 }
 

--- a/BranchSDK/src/BranchIO/Util/RequestManager.h
+++ b/BranchSDK/src/BranchIO/Util/RequestManager.h
@@ -28,7 +28,7 @@ class BRANCHIO_DLL_EXPORT RequestManager : public Poco::Runnable {
      * @param packagingInfo reference to a source of packaging information
      * @param clientSession existing client session, or NULL to start a new session
      */
-    explicit RequestManager(IPackagingInfo& packagingInfo, IClientSession* clientSession = NULL);
+    explicit RequestManager(IPackagingInfo& packagingInfo, IClientSession* clientSession = nullptr);
     ~RequestManager();
 
     /**
@@ -59,7 +59,7 @@ class BRANCHIO_DLL_EXPORT RequestManager : public Poco::Runnable {
      */
     RequestManager& enqueue(
         const Event& event,
-        IRequestCallback* callback = NULL,
+        IRequestCallback* callback = nullptr,
         bool urgent = false);
 
     /**

--- a/BranchSDK/src/BranchIO/Util/UnixStorage.cpp
+++ b/BranchSDK/src/BranchIO/Util/UnixStorage.cpp
@@ -12,7 +12,7 @@ using namespace Poco::Util;
 
 namespace BranchIO {
 
-UnixStorage&
+IStorage&
 UnixStorage::instance() {
     static UnixStorage _instance;
     return _instance;

--- a/BranchSDK/src/BranchIO/Util/UnixStorage.cpp
+++ b/BranchSDK/src/BranchIO/Util/UnixStorage.cpp
@@ -38,7 +38,7 @@ UnixStorage::has(const std::string& key, Scope scope) const {
 }
 
 bool
-UnixStorage::get(const std::string& key, std::string& value, Scope scope) const {
+UnixStorage::getString(const std::string& key, std::string& value, Scope scope) const {
     Mutex::ScopedLock _l(_mutex);
     StoragePtr config(getConfig(scope));
     if (!config->has(key)) return false;
@@ -47,9 +47,27 @@ UnixStorage::get(const std::string& key, std::string& value, Scope scope) const 
 }
 
 IStorage&
-UnixStorage::set(const std::string& key, const std::string& value, Scope scope) {
+UnixStorage::setString(const std::string& key, const std::string& value, Scope scope) {
     Mutex::ScopedLock _l(_mutex);
     getConfig(scope)->setString(key, value);
+    flush(scope);
+    return *this;
+}
+
+bool
+UnixStorage::getBoolean(const std::string& key, bool& value, Scope scope) const {
+    Mutex::ScopedLock _l(_mutex);
+    StoragePtr config(getConfig(scope));
+    if (!config->has(key)) return false;
+    value = config->getBool(key, false);
+
+    return true;
+}
+
+IStorage&
+UnixStorage::setBoolean(const std::string& key, bool value, Scope scope) {
+    Mutex::ScopedLock _l(_mutex);
+    getConfig(scope)->setBool(key, value);
     flush(scope);
     return *this;
 }

--- a/BranchSDK/src/BranchIO/Util/UnixStorage.cpp
+++ b/BranchSDK/src/BranchIO/Util/UnixStorage.cpp
@@ -98,7 +98,7 @@ UnixStorage::clear(Scope scope) {
     }
 
     File file(getPath(scope));
-    file.remove(true);  // recursively removes the directory
+    if (file.exists()) file.remove(true);  // recursively removes the directory
 
     return *this;
 }

--- a/BranchSDK/src/BranchIO/Util/UnixStorage.cpp
+++ b/BranchSDK/src/BranchIO/Util/UnixStorage.cpp
@@ -37,13 +37,13 @@ UnixStorage::has(const std::string& key, Scope scope) const {
     return getConfig(scope)->has(key);
 }
 
-bool
-UnixStorage::getString(const std::string& key, std::string& value, Scope scope) const {
+std::string
+UnixStorage::getString(const std::string& key, const std::string& defaultValue, Scope scope) const {
     Mutex::ScopedLock _l(_mutex);
     StoragePtr config(getConfig(scope));
-    if (!config->has(key)) return false;
-    value = config->getString(key);
-    return true;
+    if (!config->has(key)) return defaultValue;
+
+    return config->getString(key);
 }
 
 IStorage&
@@ -55,13 +55,12 @@ UnixStorage::setString(const std::string& key, const std::string& value, Scope s
 }
 
 bool
-UnixStorage::getBoolean(const std::string& key, bool& value, Scope scope) const {
+UnixStorage::getBoolean(const std::string& key, bool defaultValue, Scope scope) const {
     Mutex::ScopedLock _l(_mutex);
     StoragePtr config(getConfig(scope));
-    if (!config->has(key)) return false;
-    value = config->getBool(key, false);
+    if (!config->has(key)) return defaultValue;
 
-    return true;
+    return config->getBool(key, false);
 }
 
 IStorage&

--- a/BranchSDK/src/BranchIO/Util/UnixStorage.h
+++ b/BranchSDK/src/BranchIO/Util/UnixStorage.h
@@ -32,7 +32,7 @@ class UnixStorage : public virtual IStorage {
      * Singleton accessor
      * @return the single UnixStorage instance
      */
-    static UnixStorage& instance();
+    static IStorage& instance();
 
     /**
      * @copydoc IStorage::getDefaultScope

--- a/BranchSDK/src/BranchIO/Util/UnixStorage.h
+++ b/BranchSDK/src/BranchIO/Util/UnixStorage.h
@@ -50,14 +50,24 @@ class UnixStorage : public virtual IStorage {
     bool has(const std::string& key, Scope scope = Default) const;
 
     /**
-     * @copydoc IStorage::get
+     * @copydoc IStorage::getString
      */
-    bool get(const std::string& key, std::string& value, Scope scope = Default) const;
+    bool getString(const std::string& key, std::string& value, Scope scope = Default) const;
 
     /**
-     * @copydoc IStorage::set
+     * @copydoc IStorage::setString
      */
-    IStorage& set(const std::string& key, const std::string& value, Scope scope = Default);
+    IStorage& setString(const std::string& key, const std::string& value, Scope scope = Default);
+
+    /**
+     * @copydoc IStorage::getBoolean
+     */
+    bool getBoolean(const std::string& key, bool& value, Scope scope = Default) const;
+
+    /**
+     * @copydoc IStorage::setBoolean
+     */
+    IStorage& setBoolean(const std::string& key, bool value, Scope scope = Default);
 
     /**
      * @copydoc IStorage::remove

--- a/BranchSDK/src/BranchIO/Util/UnixStorage.h
+++ b/BranchSDK/src/BranchIO/Util/UnixStorage.h
@@ -52,7 +52,7 @@ class UnixStorage : public virtual IStorage {
     /**
      * @copydoc IStorage::getString
      */
-    bool getString(const std::string& key, std::string& value, Scope scope = Default) const;
+    std::string getString(const std::string& key, const std::string& defaultValue = "", Scope scope = Default) const;
 
     /**
      * @copydoc IStorage::setString
@@ -62,7 +62,7 @@ class UnixStorage : public virtual IStorage {
     /**
      * @copydoc IStorage::getBoolean
      */
-    bool getBoolean(const std::string& key, bool& value, Scope scope = Default) const;
+    bool getBoolean(const std::string& key, bool defaultValue = false, Scope scope = Default) const;
 
     /**
      * @copydoc IStorage::setBoolean

--- a/BranchSDK/src/BranchIO/Util/WindowsStorage.cpp
+++ b/BranchSDK/src/BranchIO/Util/WindowsStorage.cpp
@@ -13,7 +13,7 @@ using namespace Poco::Util;
 
 namespace BranchIO {
 
-WindowsStorage&
+IStorage&
 WindowsStorage::instance() {
     static WindowsStorage _instance;
     return _instance;

--- a/BranchSDK/src/BranchIO/Util/WindowsStorage.cpp
+++ b/BranchSDK/src/BranchIO/Util/WindowsStorage.cpp
@@ -109,16 +109,15 @@ WindowsStorage::has(const std::string& key, Scope scope) const {
     return WinRegistryKey(registryKey).exists(registryPath);
 }
 
-bool
-WindowsStorage::getString(const std::string& key, std::string& value, Scope scope) const {
+std::string
+WindowsStorage::getString(const std::string& key, const std::string& defaultValue, Scope scope) const {
     string registryKey, registryPath;
     bool validKey(getRegistryKeyAndPath(scope, key, registryKey, registryPath));
     assert(validKey);
 
-    if (!has(key, scope)) return false;
+    if (!has(key, scope)) return defaultValue;
 
-    value = WinRegistryKey(registryKey).getString(registryPath);
-    return true;
+    return WinRegistryKey(registryKey).getString(registryPath);
 }
 
 IStorage&
@@ -133,17 +132,15 @@ WindowsStorage::setString(const std::string& key, const std::string& value, Scop
 }
 
 bool
-WindowsStorage::getBoolean(const std::string& key, bool& value, Scope scope) const {
+WindowsStorage::getBoolean(const std::string& key, bool defaultValue, Scope scope) const {
     string registryKey, registryPath;
     bool validKey(getRegistryKeyAndPath(scope, key, registryKey, registryPath));
     assert(validKey);
 
-    if (!has(key, scope)) return false;
+    if (!has(key, scope)) return defaultValue;
 
     int v = WinRegistryKey(registryKey).getInt(registryPath);
-    value = (v == 0 ? false : true);
-
-    return true;
+    return (v == 0 ? false : true);
 }
 
 IStorage&

--- a/BranchSDK/src/BranchIO/Util/WindowsStorage.cpp
+++ b/BranchSDK/src/BranchIO/Util/WindowsStorage.cpp
@@ -110,7 +110,7 @@ WindowsStorage::has(const std::string& key, Scope scope) const {
 }
 
 bool
-WindowsStorage::get(const std::string& key, std::string& value, Scope scope) const {
+WindowsStorage::getString(const std::string& key, std::string& value, Scope scope) const {
     string registryKey, registryPath;
     bool validKey(getRegistryKeyAndPath(scope, key, registryKey, registryPath));
     assert(validKey);
@@ -122,12 +122,37 @@ WindowsStorage::get(const std::string& key, std::string& value, Scope scope) con
 }
 
 IStorage&
-WindowsStorage::set(const std::string& key, const std::string& value, Scope scope) {
+WindowsStorage::setString(const std::string& key, const std::string& value, Scope scope) {
     string registryKey, registryPath;
     bool validKey(getRegistryKeyAndPath(scope, key, registryKey, registryPath));
     assert(validKey);
 
     WinRegistryKey(registryKey).setString(registryPath, value);
+
+    return *this;
+}
+
+bool
+WindowsStorage::getBoolean(const std::string& key, bool& value, Scope scope) const {
+    string registryKey, registryPath;
+    bool validKey(getRegistryKeyAndPath(scope, key, registryKey, registryPath));
+    assert(validKey);
+
+    if (!has(key, scope)) return false;
+
+    int v = WinRegistryKey(registryKey).getInt(registryPath);
+    value = (v == 0 ? false : true);
+
+    return true;
+}
+
+IStorage&
+WindowsStorage::setBoolean(const std::string& key, bool value, Scope scope) {
+    string registryKey, registryPath;
+    bool validKey(getRegistryKeyAndPath(scope, key, registryKey, registryPath));
+    assert(validKey);
+
+    WinRegistryKey(registryKey).setInt(registryPath, (value ? 1 : 0));
 
     return *this;
 }

--- a/BranchSDK/src/BranchIO/Util/WindowsStorage.cpp
+++ b/BranchSDK/src/BranchIO/Util/WindowsStorage.cpp
@@ -53,25 +53,29 @@ WindowsStorage::getRegistryKeyAndPath(
         return false;  // in case int case to Scope enum
     }
 
-    string regKey, regPath;
-    if (!splitRegistryKeyAndPath(key, regKey, regPath)) return false;
+    // Glue everything together into one long root\a\b\c
+    string path = rootPath + "\\" + convertKey(key);
 
-    registryKey = rootPath + "\\" + convertKey(regKey);
+    // Split the root\a\b  and \c
+    string regKey, regPath;
+    if (!splitRegistryKeyAndPath(path, regKey, regPath)) return false;
+
     registryPath = regPath;
+    registryKey = regKey;
 
     return true;
 }
 
 bool
 WindowsStorage::splitRegistryKeyAndPath(const std::string& key, std::string& registryKey, std::string& registryPath) {
-    // split off the last component, e.g. key="a.b.c" -> registryKey="a.b", registryPath="c"
+    // split off the last component, e.g. key="a\b\c" -> registryKey="a\b", registryPath="c"
     // fails if not at least two components
 
-    string::size_type lastDot = key.find_last_of(".");
-    if (lastDot == string::npos) return false;
+    string::size_type lastDelim = key.find_last_of("\\");
+    if (lastDelim == string::npos) return false;
 
-    registryKey = key.substr(0, lastDot);
-    registryPath = key.substr(lastDot + 1);  // to end of string
+    registryKey = key.substr(0, lastDelim);
+    registryPath = key.substr(lastDelim + 1);  // to end of string
 
     return true;
 }

--- a/BranchSDK/src/BranchIO/Util/WindowsStorage.h
+++ b/BranchSDK/src/BranchIO/Util/WindowsStorage.h
@@ -49,14 +49,24 @@ class WindowsStorage : public virtual IStorage {
     bool has(const std::string& key, Scope scope = Default) const;
 
     /**
-     * @copydoc IStorage::get
+     * @copydoc IStorage::getString
      */
-    bool get(const std::string& key, std::string& value, Scope scope = Default) const;
+    bool getString(const std::string& key, std::string& value, Scope scope = Default) const;
 
     /**
-     * @copydoc IStorage::set
+     * @copydoc IStorage::setString
      */
-    IStorage& set(const std::string& key, const std::string& value, Scope scope = Default);
+    IStorage& setString(const std::string& key, const std::string& value, Scope scope = Default);
+
+    /**
+     * @copydoc IStorage::getBoolean
+     */
+    bool getBoolean(const std::string& key, bool& value, Scope scope = Default) const;
+
+    /**
+     * @copydoc IStorage::setBoolean
+     */
+    IStorage& setBoolean(const std::string& key, bool value, Scope scope = Default);
 
     /**
      * @copydoc IStorage::remove

--- a/BranchSDK/src/BranchIO/Util/WindowsStorage.h
+++ b/BranchSDK/src/BranchIO/Util/WindowsStorage.h
@@ -31,7 +31,7 @@ class WindowsStorage : public virtual IStorage {
      * Singleton accessor
      * @return the single WindowsStorage instance
      */
-    static WindowsStorage& instance();
+    static IStorage& instance();
 
     /**
      * @copydoc IStorage::getDefaultScope

--- a/BranchSDK/src/BranchIO/Util/WindowsStorage.h
+++ b/BranchSDK/src/BranchIO/Util/WindowsStorage.h
@@ -51,7 +51,7 @@ class WindowsStorage : public virtual IStorage {
     /**
      * @copydoc IStorage::getString
      */
-    bool getString(const std::string& key, std::string& value, Scope scope = Default) const;
+    std::string getString(const std::string& key, const std::string& defaultValue = "", Scope scope = Default) const;
 
     /**
      * @copydoc IStorage::setString
@@ -61,7 +61,7 @@ class WindowsStorage : public virtual IStorage {
     /**
      * @copydoc IStorage::getBoolean
      */
-    bool getBoolean(const std::string& key, bool& value, Scope scope = Default) const;
+    bool getBoolean(const std::string& key, bool defaultValue = false, Scope scope = Default) const;
 
     /**
      * @copydoc IStorage::setBoolean

--- a/BranchSDK/test/StorageTest.cpp
+++ b/BranchSDK/test/StorageTest.cpp
@@ -69,7 +69,7 @@ TEST_F(StorageTest, TestDefaultString)
 }
 
 // Test loading values that are not there
-TEST_F(StorageTest, TestNotFound) {
+TEST_F(StorageTest, TestKeyNotFound) {
     bool found = Storage::instance().has(_testStringKey);
     ASSERT_FALSE(found);
 

--- a/BranchSDK/test/StorageTest.cpp
+++ b/BranchSDK/test/StorageTest.cpp
@@ -77,7 +77,7 @@ TEST_F(StorageTest, TestKeyNotFound) {
     ASSERT_FALSE(found);
 }
 
-TEST_F(StorageTest, TestRemove) {
+TEST_F(StorageTest, TestAddRemove) {
     StorageTest_TestAddString_Test();
     StorageTest_TestAddBoolean_Test();
 
@@ -85,4 +85,19 @@ TEST_F(StorageTest, TestRemove) {
     Storage::instance().remove(_testBooleanKey);
 
     StorageTest_TestKeyNotFound_Test();
+}
+
+TEST_F(StorageTest, TestDefaultScope) {
+    Storage::instance().setDefaultScope(Storage::Default);
+    StorageTest_TestAddRemove_Test();
+}
+
+TEST_F(StorageTest, TestHostScope) {
+    Storage::instance().setDefaultScope(Storage::Host);
+    StorageTest_TestAddRemove_Test();
+}
+
+TEST_F(StorageTest, TestUserScope) {
+    Storage::instance().setDefaultScope(Storage::User);
+    StorageTest_TestAddRemove_Test();
 }

--- a/BranchSDK/test/StorageTest.cpp
+++ b/BranchSDK/test/StorageTest.cpp
@@ -1,0 +1,72 @@
+#include <string>
+
+// Use <gtest/gtest.h> when not using mocks.
+// Otherwise <gmock/gmock.h> also brings in gtest.
+#include <gtest/gtest.h>
+
+#include <BranchIO/Util/Storage.h>
+
+using namespace BranchIO;
+using namespace std;
+
+class StorageTest : public ::testing::Test
+{
+    virtual void SetUp() {
+        Storage::instance().setDefaultScope(Storage::User);
+        Storage::instance().clear(Storage::User);
+    }
+
+    virtual void TearDown() {
+        Storage::instance().clear(Storage::User);
+    }
+
+ public:
+    const std::string _testStringKey = "TestStringKey";
+    const std::string _testStringValue = "TestValue";
+
+    const std::string _testBooleanKey = "TestBooleanKey";
+    const bool _testBooleanValue = true;
+};
+
+TEST_F(StorageTest, TestAddString)
+{
+    Storage::instance().setString(_testStringKey, _testStringValue);
+
+    std::string result;
+    bool found = Storage::instance().getString(_testStringKey, result);
+
+    ASSERT_TRUE(found);
+    ASSERT_EQ(_testStringValue, result);
+}
+
+TEST_F(StorageTest, TestAddBoolean)
+{
+    Storage::instance().setBoolean(_testBooleanKey, _testBooleanValue);
+
+    bool result = false;
+    bool found = Storage::instance().getBoolean(_testBooleanKey, result);
+
+    ASSERT_TRUE(found);
+    ASSERT_EQ(_testBooleanValue, result);
+}
+
+// Test loading values that are not there
+TEST_F(StorageTest, TestNotFound) {
+    std::string resultString;
+    bool found = Storage::instance().getString(_testStringKey, resultString);
+    ASSERT_FALSE(found);
+
+    bool resultBool = true;
+    found = Storage::instance().getBoolean(_testBooleanKey, resultBool);
+    ASSERT_FALSE(found);
+}
+
+TEST_F(StorageTest, TestRemove) {
+    StorageTest_TestAddString_Test();
+    StorageTest_TestAddBoolean_Test();
+
+    Storage::instance().remove(_testStringKey);
+    Storage::instance().remove(_testBooleanKey);
+
+    StorageTest_TestNotFound_Test();
+}

--- a/BranchSDK/test/StorageTest.cpp
+++ b/BranchSDK/test/StorageTest.cpp
@@ -84,5 +84,5 @@ TEST_F(StorageTest, TestRemove) {
     Storage::instance().remove(_testStringKey);
     Storage::instance().remove(_testBooleanKey);
 
-    StorageTest_TestNotFound_Test();
+    StorageTest_TestKeyNotFound_Test();
 }

--- a/BranchSDK/test/StorageTest.cpp
+++ b/BranchSDK/test/StorageTest.cpp
@@ -32,10 +32,10 @@ TEST_F(StorageTest, TestAddString)
 {
     Storage::instance().setString(_testStringKey, _testStringValue);
 
-    std::string result;
-    bool found = Storage::instance().getString(_testStringKey, result);
-
+    bool found = Storage::instance().has(_testStringKey);
     ASSERT_TRUE(found);
+
+    std::string result = Storage::instance().getString(_testStringKey);
     ASSERT_EQ(_testStringValue, result);
 }
 
@@ -43,21 +43,37 @@ TEST_F(StorageTest, TestAddBoolean)
 {
     Storage::instance().setBoolean(_testBooleanKey, _testBooleanValue);
 
-    bool result = false;
-    bool found = Storage::instance().getBoolean(_testBooleanKey, result);
-
+    bool found = Storage::instance().has(_testBooleanKey);
     ASSERT_TRUE(found);
+
+    bool result = Storage::instance().getBoolean(_testBooleanKey);
     ASSERT_EQ(_testBooleanValue, result);
+}
+
+TEST_F(StorageTest, TestDefaultBoolean)
+{
+    bool result = Storage::instance().getBoolean(_testBooleanKey);
+    ASSERT_FALSE(result);
+
+    result = Storage::instance().getBoolean(_testBooleanKey, true);
+    ASSERT_TRUE(result);
+}
+
+TEST_F(StorageTest, TestDefaultString)
+{
+    std::string result = Storage::instance().getString(_testStringKey);
+    ASSERT_TRUE(result.empty());
+
+    result = Storage::instance().getString(_testStringKey, _testStringValue);
+    ASSERT_EQ(_testStringValue, result);
 }
 
 // Test loading values that are not there
 TEST_F(StorageTest, TestNotFound) {
-    std::string resultString;
-    bool found = Storage::instance().getString(_testStringKey, resultString);
+    bool found = Storage::instance().has(_testStringKey);
     ASSERT_FALSE(found);
 
-    bool resultBool = true;
-    found = Storage::instance().getBoolean(_testBooleanKey, resultBool);
+    found = Storage::instance().has(_testBooleanKey);
     ASSERT_FALSE(found);
 }
 


### PR DESCRIPTION
## Reference
SDK-632 -- Disable Tracking option does not persist throughout multiple sessions.

## Description
We were not saving the Tracking State to shared preferences.   

## Testing Instructions
1. Disable tracking
2. Send an open request and verify it's unsuccessful
3. Close the app
4. Open it again
5. Send another Open Request

Expected Results:  Verify the request was *not* sent, nor should any other requests be sent until Enable Tracking is sent.

## Risk Assessment [`HIGH`]
Lots and lots of changes happened to make this work.

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/cppguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
