### PR TITLE
SDK-647 -- Standardize create link API

### DIFF
--- a/BranchSDK-Samples/Windows/ColorPicker/ColorPicker.cpp
+++ b/BranchSDK-Samples/Windows/ColorPicker/ColorPicker.cpp
@@ -417,7 +417,7 @@ void shareColor(HWND hwnd)
     linkInfo.addControlParameter("extra_color", ColorRefToInt(_colorBackground));
 
     // Seed the box with a long URL
-    std::string longUrl = linkInfo.createLongUrl(_branchInstance->getBranchKey());
+    std::string longUrl = linkInfo.createLongUrl(_branchInstance);
     SetWindowTextA(hwndStatus, longUrl.c_str());
 
     // Create the short URL

--- a/BranchSDK/src/BranchIO/LinkInfo.cpp
+++ b/BranchSDK/src/BranchIO/LinkInfo.cpp
@@ -49,7 +49,7 @@ class LinkFallback : public IRequestCallback {
 
     virtual void onError(int id, int error, std::string description) {
         // Attempt to create a Long Link
-        std::string longUrl = _context.createLongUrl(_instance->getBranchKey());
+        std::string longUrl = _context.createLongUrl(_instance);
 
         JSONObject jsonObject;
         jsonObject.set(JSONKEY_URL, longUrl);
@@ -182,12 +182,12 @@ LinkInfo::createUrl(Branch *branchInstance, IRequestCallback *callback) {
 
 
 std::string
-LinkInfo::createLongUrl(const std::string &branchKey, const std::string &baseUrl) const {
+LinkInfo::createLongUrl(Branch *branchInstance, const std::string &baseUrl) const {
     // TODO(andyp): Handle response from setIdentity if there is a base URL in the response
 
     std::string longUrl;
     longUrl += (baseUrl.size() > 0 ? baseUrl : BASE_LONG_URL);
-    longUrl += branchKey;
+    longUrl += branchInstance->getBranchKey();
 
     Poco::URI uri(longUrl);
 

--- a/BranchSDK/src/BranchIO/LinkInfo.h
+++ b/BranchSDK/src/BranchIO/LinkInfo.h
@@ -147,11 +147,11 @@ class BRANCHIO_DLL_EXPORT LinkInfo : protected Event {
     /**
      * Create a long Url with the given deep link parameters and link properties.
      * Note that this does not require an active network connection.
-     * @param branchKey Branch Key.
+     * @param branchInstance Branch Instance.
      * @param baseUrl Non-Default base to use for forming the url
      * @return A url with the given deep link parameters.
      */
-    virtual std::string createLongUrl(const std::string &branchKey, const std::string &baseUrl = "") const;
+    virtual std::string createLongUrl(Branch *branchInstance, const std::string &baseUrl = "") const;
 
     using PropertyManager::toString;
 

--- a/BranchSDK/test/LinkInfoTest.cpp
+++ b/BranchSDK/test/LinkInfoTest.cpp
@@ -143,10 +143,11 @@ TEST_F(LinkInfoTest, TestLinkCreate) {
 
 // Test to create a "Long Link Url" from a LinkInfo
 TEST_F(LinkInfoTest, TestLongLinkCreate) {
+    Branch *_branchInstance = BranchIO::Test::createTestInstance();
     LinkInfo linkInfo;
     initTestLink(linkInfo);
 
-    std::string longUrl = linkInfo.createLongUrl(BranchIO::Test::getTestKey());
+    std::string longUrl = linkInfo.createLongUrl(_branchInstance);
 
     cout << "TestLongLinkCreate:\t" << longUrl << endl;
 }
@@ -183,8 +184,9 @@ TEST_F(LinkInfoTest, TestCreateLinkUrlFallback) {
 }
 
 TEST_F(LinkInfoTest, TestCreateLinkNoControlParams) {
+    Branch *_branchInstance = BranchIO::Test::createTestInstance();
     LinkInfo linkInfo;
-    std::string url = linkInfo.createLongUrl(BranchIO::Test::getTestKey());
+    std::string url = linkInfo.createLongUrl(_branchInstance);
 
     ASSERT_GT(url.size(), 0);
 }


### PR DESCRIPTION
## Reference
SDK-647 -- Standardize create link API

## Description
While producing documentation, I found that Short and Long Links have a slightly different API.

Quick fix to standardize these.

## Testing Instructions
* Unit Tests Pass

## Risk Assessment [`LOW`]
Simple API change.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/cppguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
