### PR TITLE
SDK-644 -- Create a base event interface

### DIFF
--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -168,7 +168,7 @@ Branch::closeSession(IRequestCallback *callback) {
 }
 
 void
-Branch::sendEvent(const Event &event, IRequestCallback *callback) {
+Branch::sendEvent(const BaseEvent &event, IRequestCallback *callback) {
     if (getAdvertiserInfo().isTrackingDisabled()) {
         if (callback) {
             callback->onStatus(0, 0, "Requested operation cannot be completed since tracking is disabled");

--- a/BranchSDK/src/BranchIO/Branch.h
+++ b/BranchSDK/src/BranchIO/Branch.h
@@ -11,7 +11,7 @@
 #include "BranchIO/AdvertiserInfo.h"
 #include "BranchIO/AppInfo.h"
 #include "BranchIO/DeviceInfo.h"
-#include "BranchIO/Event/Event.h"
+#include "BranchIO/Event/BaseEvent.h"
 #include "BranchIO/PackagingInfo.h"
 #include "BranchIO/IRequestCallback.h"
 #include "BranchIO/SessionInfo.h"
@@ -65,10 +65,10 @@ class BRANCHIO_DLL_EXPORT Branch {
 
     /**
      * Send an event to Branch.
-     * @param event Event to send
+     * @param event BaseEvent to send
      * @param callback Callback to fire with success or failure notification.
      */
-    virtual void sendEvent(const Event &event, IRequestCallback *callback);
+    virtual void sendEvent(const BaseEvent &event, IRequestCallback *callback);
 
     /**
      * @return the SDK Version

--- a/BranchSDK/src/BranchIO/Event/BaseEvent.cpp
+++ b/BranchSDK/src/BranchIO/Event/BaseEvent.cpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2019 Branch Metrics, Inc.
+
+#include "BaseEvent.h"
+#include "BranchIO/AppInfo.h"
+#include "BranchIO/Defines.h"
+#include "BranchIO/DeviceInfo.h"
+#include "BranchIO/IPackagingInfo.h"
+#include "BranchIO/JSONObject.h"
+#include "BranchIO/SessionInfo.h"
+#include "BranchIO/AdvertiserInfo.h"
+
+namespace BranchIO {
+
+// Top Level JSON Blocks
+static const char *JSONKEY_NAME = "name";
+static const char *JSONKEY_CUSTOM_DATA = "custom_data";
+static const char *JSONKEY_EVENT_DATA = "event_data";
+static const char *JSONKEY_USER_DATA = "user_data";
+static const char *JSONKEY_BRANCH_KEY = "branch_key";
+static const char *JSONKEY_ADVERTISING_IDS = "advertising_ids";
+
+
+BaseEvent::BaseEvent(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr) :
+    mAPIEndpoint(apiEndpoint),
+    mEventName(eventName),
+    mCustomData(nullptr) {
+
+    if (jsonPtr.get()) {
+        // Copy the key/values
+        for (JSONObject::ConstIterator it = jsonPtr->begin(); it != jsonPtr->end(); ++it) {
+            set(it->first, it->second);
+        }
+    }
+}
+
+BaseEvent::~BaseEvent() = default;
+
+BaseEvent&
+BaseEvent::addEventProperty(const char *propertyName, const std::string &propertyValue) {
+    addProperty(propertyName, propertyValue);
+    return *this;
+}
+
+BaseEvent&
+BaseEvent::addEventProperty(const char *propertyName, double propertyValue) {
+    addProperty(propertyName, propertyValue);
+    return *this;
+}
+
+BaseEvent&
+BaseEvent::addCustomDataProperty(const std::string &propertyName, const std::string &propertyValue) {
+
+    // These go into "custom_data"
+    if (mCustomData.isNull()) {
+        mCustomData = new JSONObject();
+    }
+
+    mCustomData->set(propertyName, propertyValue);
+    return *this;
+}
+
+const JSONObject::Ptr
+BaseEvent::getCustomData() const { return mCustomData; }
+
+const std::string &
+BaseEvent::name() const { return mEventName; }
+
+Defines::APIEndpoint
+BaseEvent::getAPIEndpoint() const { return mAPIEndpoint; }
+
+void
+BaseEvent::packageRawEvent(JSONObject &jsonObject) const {
+    jsonObject.parse(PropertyManager::stringify());
+}
+
+void
+BaseEvent::packageV1Event(IPackagingInfo &packagingInfo, JSONObject &jsonObject) const {
+    jsonObject += *this;
+    jsonObject += packagingInfo.getSessionInfo().toJSON();
+    jsonObject += packagingInfo.getDeviceInfo().toJSON();
+    jsonObject += packagingInfo.getAppInfo().toJSON();
+
+    // Ad Tracking Limited
+    jsonObject.set(Defines::JSONKEY_APP_LAT_V1, (packagingInfo.getAdvertiserInfo().isTrackingLimited() ? 1 : 0));
+}
+
+void
+BaseEvent::packageV2Event(IPackagingInfo &packagingInfo, JSONObject &jsonObject) const {
+    // Set the event name
+    jsonObject.set(JSONKEY_NAME, name());
+
+    // Set the event data
+    jsonObject.set(JSONKEY_EVENT_DATA, *this);
+
+    // Set Custom Data (if any)
+    if (!getCustomData().isNull()) {
+        jsonObject.set(JSONKEY_CUSTOM_DATA, getCustomData());
+    }
+
+    // Set the user data
+    JSONObject userData;
+    JSONObject sessionInfo = packagingInfo.getSessionInfo().toJSON();
+    JSONObject deviceInfo = packagingInfo.getDeviceInfo().toJSON();
+    JSONObject appInfo = packagingInfo.getAppInfo().toJSON();
+    JSONObject adInfo = packagingInfo.getAdvertiserInfo().toJSON();
+
+    userData += sessionInfo;
+    userData += deviceInfo;
+    userData += appInfo;
+
+    // Advertising Ids
+    bool isAdTrackingLimited = packagingInfo.getAdvertiserInfo().isTrackingLimited();
+    if (!isAdTrackingLimited && adInfo.size() > 0) {
+        userData.set(JSONKEY_ADVERTISING_IDS, adInfo);
+    }
+    userData.set(Defines::JSONKEY_APP_LAT_V2, (isAdTrackingLimited ? 1 : 0));
+
+    jsonObject.set(JSONKEY_USER_DATA, userData);
+}
+
+void
+BaseEvent::package(IPackagingInfo &packagingInfo, JSONObject &jsonPackage) const {
+    // Set the Branch Key
+    jsonPackage.set(JSONKEY_BRANCH_KEY, packagingInfo.getBranchKey());
+
+    switch (Defines::endpointType(getAPIEndpoint())) {
+        case Defines::V1:
+            packageV1Event(packagingInfo, jsonPackage);
+            break;
+
+        case Defines::V2:
+            packageV2Event(packagingInfo, jsonPackage);
+            break;
+
+        case Defines::RAW:
+        default:
+            // Dump the raw event data into the request and hope for the best
+            packageRawEvent(jsonPackage);
+            break;
+    }
+
+}
+
+
+}  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/Event/BaseEvent.h
+++ b/BranchSDK/src/BranchIO/Event/BaseEvent.h
@@ -1,0 +1,102 @@
+// Copyright (c) 2019 Branch Metrics, Inc.
+
+#ifndef BRANCHIO_EVENT_BASEEVENT_H_
+#define BRANCHIO_EVENT_BASEEVENT_H_
+
+#include <string>
+#include "BranchIO/Defines.h"
+#include "BranchIO/fwd.h"
+#include "BranchIO/PropertyManager.h"
+
+namespace BranchIO {
+
+typedef std::string CurrencyType;
+
+/**
+ * Base class for Branch events for tracking and analytical purpose.
+ */
+class BRANCHIO_DLL_EXPORT BaseEvent : public PropertyManager {
+ public:
+    using PropertyManager::toString;
+
+    virtual ~BaseEvent();
+
+    /**
+     * @return the Event Name.
+     */
+    virtual const std::string &name() const;
+
+    /**
+     * Adds a custom data property associated with this Branch Event.
+     * @param propertyName Name of the custom property
+     * @param propertyValue Value of the custom property
+     * @return This object for chaining builder methods
+     */
+    virtual BaseEvent& addCustomDataProperty(const std::string &propertyName, const std::string &propertyValue);
+
+    /**
+     * Get the custom data properties associated with this Branch Event.
+     * @return the Custom Data for the event.
+     */
+    virtual const JSONObject::Ptr getCustomData() const;
+
+ public:
+    /**
+     * @return the API Endpoint.
+     */
+    virtual Defines::APIEndpoint getAPIEndpoint() const;
+
+    /**
+     * Prepare the event package for transmission.
+     * @param packagingInfo Context for packaging events
+     * @param jsonPackage result of the packaging process
+     * @todo(andyp) Revisit Scope
+     */
+    virtual void package(IPackagingInfo &packagingInfo, JSONObject &jsonPackage) const;
+
+ protected:
+    /**
+     * Constructor
+     * @param apiEndpoint Endpoint this event will be directed towards
+     * @param eventName The "Name" of the event
+     * @param jsonPtr Base JSON to start with
+     */
+    BaseEvent(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr = nullptr);
+
+    /**
+     * Add a Raw Event Property Name and Value
+     * @param propertyName Property Name
+     * @param propertyValue Property Value
+     * @return this object for chaining builder methods
+     */
+    BaseEvent& addEventProperty(const char *propertyName, const std::string &propertyValue);
+
+    /**
+     * Add a Raw Event Property Name and Value
+     * @param propertyName Property Name
+     * @param propertyValue Property Value
+     * @return this object for chaining builder methods
+     */
+    BaseEvent& addEventProperty(const char *propertyName, double propertyValue);
+
+ private:
+    BaseEvent();
+
+    void packageRawEvent(JSONObject &jsonObject) const;
+    void packageV1Event(IPackagingInfo &branch, JSONObject &jsonObject) const;
+    void packageV2Event(IPackagingInfo &branch, JSONObject &jsonObject) const;
+
+ private:
+    // API Endpoint
+    Defines::APIEndpoint mAPIEndpoint;
+
+    // The Event Name
+    std::string mEventName;
+
+    // Custom Data is rendered as a sibling to the event data
+    JSONObject::Ptr mCustomData;
+};
+
+}  // namespace BranchIO
+
+#endif  // BRANCHIO_EVENT_BASEEVENT_H_

--- a/BranchSDK/src/BranchIO/Event/BaseEvent.h
+++ b/BranchSDK/src/BranchIO/Event/BaseEvent.h
@@ -28,6 +28,7 @@ class BRANCHIO_DLL_EXPORT BaseEvent : public PropertyManager {
 
     /**
      * Adds a custom data property associated with this Branch Event.
+     * Note that these properties are protocol-specific, and may not be sent in all cases.
      * @param propertyName Name of the custom property
      * @param propertyValue Value of the custom property
      * @return This object for chaining builder methods

--- a/BranchSDK/src/BranchIO/Event/Event.cpp
+++ b/BranchSDK/src/BranchIO/Event/Event.cpp
@@ -1,24 +1,10 @@
 // Copyright (c) 2019 Branch Metrics, Inc.
 
-#include "BranchIO/Event/Event.h"
-#include "BranchIO/AppInfo.h"
+#include "Event.h"
 #include "BranchIO/Defines.h"
-#include "BranchIO/DeviceInfo.h"
-#include "BranchIO/IPackagingInfo.h"
 #include "BranchIO/JSONObject.h"
-#include "BranchIO/SessionInfo.h"
-#include "BranchIO/AdvertiserInfo.h"
 
 namespace BranchIO {
-
-// Top Level JSON Blocks
-static const char *JSONKEY_NAME = "name";
-static const char *JSONKEY_CUSTOM_DATA = "custom_data";
-static const char *JSONKEY_EVENT_DATA = "event_data";
-static const char *JSONKEY_USER_DATA = "user_data";
-// static const char *JSONKEY_METADATA = "metadata";
-static const char *JSONKEY_BRANCH_KEY = "branch_key";
-static const char *JSONKEY_ADVERTISING_IDS = "advertising_ids";
 
 // AD TYPES
 const char *AD_TYPE_BANER = "BANNER";
@@ -27,111 +13,76 @@ const char *AD_TYPE_REWARDED_VIDEO = "REWARDED_VIDEO";
 const char *AD_TYPE_NATIVE = "NATIVE";
 
 Event::Event(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr) :
-    mAPIEndpoint(apiEndpoint),
-    mEventName(eventName),
-    mCustomData(nullptr) {
-
-    if (jsonPtr.get()) {
-        // Copy the key/values
-        for (JSONObject::ConstIterator it = jsonPtr->begin(); it != jsonPtr->end(); ++it) {
-            set(it->first, it->second);
-        }
-    }
+    BaseEvent(apiEndpoint, eventName, jsonPtr) {
 }
 
-Event::~Event() { }
+Event::~Event() = default;
 
 Event&
 Event::setAdType(Event::AdType adType) {
-    return addEventProperty(Defines::JSONKEY_ADTYPE, stringify(adType));
+    addEventProperty(Defines::JSONKEY_ADTYPE, stringify(adType));
+    return *this;
 }
 
 Event&
 Event::setAffiliation(const std::string &affiliation) {
-    return addEventProperty(Defines::JSONKEY_AFFILIATION, affiliation);
+    addEventProperty(Defines::JSONKEY_AFFILIATION, affiliation);
+    return *this;
 }
 
 Event&
 Event::setCoupon(const std::string &coupon) {
-    return addEventProperty(Defines::JSONKEY_COUPON, coupon);
+    addEventProperty(Defines::JSONKEY_COUPON, coupon);
+    return *this;
 }
 
 Event&
 Event::setCurrency(const CurrencyType &currency) {
-    return addEventProperty(Defines::JSONKEY_CURRENCY, currency);
+    addEventProperty(Defines::JSONKEY_CURRENCY, currency);
+    return *this;
 }
 
 Event&
 Event::setCustomerEventAlias(const std::string &alias) {
-    return addEventProperty(Defines::JSONKEY_CUSTOMER_EVENT_ALIAS, alias);
+    addEventProperty(Defines::JSONKEY_CUSTOMER_EVENT_ALIAS, alias);
+    return *this;
 }
 
 Event&
 Event::setDescription(const std::string &description) {
-    return addEventProperty(Defines::JSONKEY_DESCRIPTION, description);
+    addEventProperty(Defines::JSONKEY_DESCRIPTION, description);
+    return *this;
 }
 
 Event&
 Event::setRevenue(double revenue) {
-    return addEventProperty(Defines::JSONKEY_REVENUE, revenue);
+    addEventProperty(Defines::JSONKEY_REVENUE, revenue);
+    return *this;
 }
 
 Event&
 Event::setSearchQuery(const std::string &searchQuery) {
-    return addEventProperty(Defines::JSONKEY_SEARCHQUERY, searchQuery);
+    addEventProperty(Defines::JSONKEY_SEARCHQUERY, searchQuery);
+    return *this;
 }
 
 Event&
-Event::setShipping(double shipping)
-{
-    return addEventProperty(Defines::JSONKEY_SHIPPING, shipping);
+Event::setShipping(double shipping) {
+    addEventProperty(Defines::JSONKEY_SHIPPING, shipping);
+    return *this;
 }
 
 Event&
 Event::setTax(double tax) {
-    return addEventProperty(Defines::JSONKEY_TAX, tax);
+    addEventProperty(Defines::JSONKEY_TAX, tax);
+    return *this;
 }
 
 Event&
 Event::setTransactionId(const std::string &transactionId) {
-    return addEventProperty(Defines::JSONKEY_TRANSACTION_ID, transactionId);
-}
-
-Event&
-Event::addEventProperty(const char *propertyName, const std::string &propertyValue) {
-    addProperty(propertyName, propertyValue);
+    addEventProperty(Defines::JSONKEY_TRANSACTION_ID, transactionId);
     return *this;
 }
-
-Event&
-Event::addEventProperty(const char *propertyName, double propertyValue) {
-    addProperty(propertyName, propertyValue);
-    return *this;
-}
-
-Event&
-Event::addCustomDataProperty(
-    const std::string &propertyName,
-    const std::string &propertyValue) {
-
-    // These go into "custom_data"
-    if (mCustomData.isNull()) {
-        mCustomData = new JSONObject();
-    }
-
-    mCustomData->set(propertyName, propertyValue);
-    return *this;
-}
-
-const JSONObject::Ptr
-Event::getCustomData() const { return mCustomData; }
-
-Defines::APIEndpoint
-Event::getAPIEndpoint() const { return mAPIEndpoint; }
-
-
-const std::string &
-Event::name() const { return mEventName; }
 
 const char *
 Event::stringify(Event::AdType adType) {
@@ -151,77 +102,5 @@ Event::stringify(Event::AdType adType) {
 
     return Defines::NO_BRANCH_VALUE;
 }
-
-
-void Event::packageRawEvent(JSONObject &jsonObject) const {
-    jsonObject.parse(PropertyManager::stringify());
-}
-
-void Event::packageV1Event(IPackagingInfo &packagingInfo, JSONObject &jsonObject) const {
-    jsonObject += *this;
-    jsonObject += packagingInfo.getSessionInfo().toJSON();
-    jsonObject += packagingInfo.getDeviceInfo().toJSON();
-    jsonObject += packagingInfo.getAppInfo().toJSON();
-
-    // Ad Tracking Limited
-    jsonObject.set(Defines::JSONKEY_APP_LAT_V1, (packagingInfo.getAdvertiserInfo().isTrackingLimited() ? 1 : 0));
-}
-
-void Event::packageV2Event(IPackagingInfo &packagingInfo, JSONObject &jsonObject) const {
-    // Set the event name
-    jsonObject.set(JSONKEY_NAME, name());
-
-    // Set the event data
-    jsonObject.set(JSONKEY_EVENT_DATA, *this);
-
-    // Set Custom Data (if any)
-    if (!getCustomData().isNull()) {
-        jsonObject.set(JSONKEY_CUSTOM_DATA, getCustomData());
-    }
-
-    // Set the user data
-    JSONObject userData;
-    JSONObject sessionInfo = packagingInfo.getSessionInfo().toJSON();
-    JSONObject deviceInfo = packagingInfo.getDeviceInfo().toJSON();
-    JSONObject appInfo = packagingInfo.getAppInfo().toJSON();
-    JSONObject adInfo = packagingInfo.getAdvertiserInfo().toJSON();
-
-    userData += sessionInfo;
-    userData += deviceInfo;
-    userData += appInfo;
-
-    // Advertising Ids
-    bool isAdTrackingLimited = packagingInfo.getAdvertiserInfo().isTrackingLimited();
-    if (!isAdTrackingLimited && adInfo.size() > 0) {
-        userData.set(JSONKEY_ADVERTISING_IDS, adInfo);
-    }
-    userData.set(Defines::JSONKEY_APP_LAT_V2, (isAdTrackingLimited ? 1 : 0));
-
-    jsonObject.set(JSONKEY_USER_DATA, userData);
-}
-
-void
-Event::package(IPackagingInfo &packagingInfo, JSONObject &jsonPackage) const {
-    // Set the Branch Key
-    jsonPackage.set(JSONKEY_BRANCH_KEY, packagingInfo.getBranchKey());
-
-    switch (Defines::endpointType(getAPIEndpoint())) {
-        case Defines::V1:
-            packageV1Event(packagingInfo, jsonPackage);
-            break;
-
-        case Defines::V2:
-            packageV2Event(packagingInfo, jsonPackage);
-            break;
-
-        case Defines::RAW:
-        default:
-            // Dump the raw event data into the request and hope for the best
-            packageRawEvent(jsonPackage);
-            break;
-    }
-
-}
-
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/Event/Event.h
+++ b/BranchSDK/src/BranchIO/Event/Event.h
@@ -4,9 +4,8 @@
 #define BRANCHIO_EVENT_EVENT_H_
 
 #include <string>
+#include "BaseEvent.h"
 #include "BranchIO/Defines.h"
-#include "BranchIO/fwd.h"
-#include "BranchIO/PropertyManager.h"
 
 namespace BranchIO {
 
@@ -15,7 +14,7 @@ typedef std::string CurrencyType;
 /**
  * Base class for Branch events for tracking and analytical purpose.
  */
-class BRANCHIO_DLL_EXPORT Event : public PropertyManager {
+class BRANCHIO_DLL_EXPORT Event : public BaseEvent {
  public:
     /**
      * Ad Types
@@ -107,43 +106,6 @@ class BRANCHIO_DLL_EXPORT Event : public PropertyManager {
      */
     virtual Event& setTransactionId(const std::string &transactionId);
 
-    /**
-     * Adds a custom data property associated with this Branch Event.
-     * @param propertyName Name of the custom property
-     * @param propertyValue Value of the custom property
-     * @return This object for chaining builder methods
-     */
-    virtual Event& addCustomDataProperty(
-        const std::string &propertyName,
-        const std::string &propertyValue);
-
-    /**
-     * Get the custom data properties associated with this Branch Event.
-     * @return the Custom Data for the event.
-     */
-    virtual const JSONObject::Ptr getCustomData() const;
-
-    /**
-     * @return the Event Name.
-     */
-    virtual const std::string &name() const;
-
-    using PropertyManager::toString;
-
- public:
-    /**
-     * @return the API Endpoint.
-     */
-    virtual Defines::APIEndpoint getAPIEndpoint() const;
-
-    /**
-     * Prepare the event package for transmission.
-     * @param packagingInfo Context for packaging events
-     * @param jsonPackage result of the packaging process
-     * @todo(andyp) Revisit Scope
-     */
-    virtual void package(IPackagingInfo &packagingInfo, JSONObject &jsonPackage) const;
-
  protected:
     /**
      * Constructor
@@ -153,40 +115,10 @@ class BRANCHIO_DLL_EXPORT Event : public PropertyManager {
      */
     Event(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr = nullptr);
 
-    /**
-     * Add a Raw Event Property Name and Value
-     * @param propertyName Property Name
-     * @param propertyValue Property Value
-     * @return this object for chaining builder methods
-     */
-    Event& addEventProperty(const char *propertyName, const std::string &propertyValue);
-
-    /**
-     * Add a Raw Event Property Name and Value
-     * @param propertyName Property Name
-     * @param propertyValue Property Value
-     * @return this object for chaining builder methods
-     */
-    Event& addEventProperty(const char *propertyName, double propertyValue);
-
  private:
     Event();
 
     static const char *stringify(Event::AdType adType);
-
-    void packageRawEvent(JSONObject &jsonObject) const;
-    void packageV1Event(IPackagingInfo &branch, JSONObject &jsonObject) const;
-    void packageV2Event(IPackagingInfo &branch, JSONObject &jsonObject) const;
-
- private:
-    // API Endpoint
-    Defines::APIEndpoint mAPIEndpoint;
-
-    // The Event Name
-    std::string mEventName;
-
-    // Custom Data is rendered as a sibling to the event data
-    JSONObject::Ptr mCustomData;
 };
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/Event/IdentityEvent.h
+++ b/BranchSDK/src/BranchIO/Event/IdentityEvent.h
@@ -5,37 +5,50 @@
 
 #include <string>
 
-#include "BranchIO/Event/Event.h"
-#include "BranchIO/JSONObject.h"
+#include "BranchIO/Event/BaseEvent.h"
 
 namespace BranchIO {
 
 /**
+ * (Internal) Identity Event
+ */
+class BRANCHIO_DLL_EXPORT IdentityEvent : public BaseEvent {
+ public:
+    /**
+     * Constructor.
+     * @param apiEndpoint API endpoint
+     * @param eventName Event Name
+     */
+    IdentityEvent(Defines::APIEndpoint apiEndpoint, const std::string &eventName) :
+        BaseEvent(apiEndpoint, eventName) {}
+};
+
+/**
  * (Internal) User Identity Login Event
  */
-class BRANCHIO_DLL_EXPORT IdentityLoginEvent : public Event {
+class BRANCHIO_DLL_EXPORT IdentityLoginEvent : public IdentityEvent {
  public:
     /**
      * Constructor.
      * @param identity A value containing the unique identifier of the user
      */
     IdentityLoginEvent(std::string identity) :
-            Event(Defines::APIEndpoint::IDENTIFY_USER, "setIdentity") {
+            IdentityEvent(Defines::APIEndpoint::IDENTIFY_USER, "setIdentity") {
 
-        Event::addEventProperty(Defines::JSONKEY_APP_IDENTITY, identity);
+        addEventProperty(Defines::JSONKEY_APP_IDENTITY, identity);
     }
 };
 
 /**
  * (Internal) User Identity Logout Event
  */
-class BRANCHIO_DLL_EXPORT IdentityLogoutEvent : public Event {
-public:
+class BRANCHIO_DLL_EXPORT IdentityLogoutEvent : public IdentityEvent {
+ public:
     /**
      * Constructor.
      */
     explicit IdentityLogoutEvent() :
-            Event(Defines::APIEndpoint::LOGOUT, "logout") {
+            IdentityEvent(Defines::APIEndpoint::LOGOUT, "logout") {
     }
 };
 

--- a/BranchSDK/src/BranchIO/Event/SessionEvent.h
+++ b/BranchSDK/src/BranchIO/Event/SessionEvent.h
@@ -13,7 +13,7 @@ namespace BranchIO {
 /**
  * (Internal) Session Management Event
  */
-class BRANCHIO_DLL_EXPORT SessionEvent : public Event {
+class BRANCHIO_DLL_EXPORT SessionEvent : public BaseEvent {
  public:
     /**
      * Constructor.
@@ -21,7 +21,7 @@ class BRANCHIO_DLL_EXPORT SessionEvent : public Event {
      * @param eventName Event Name
      */
     SessionEvent(Defines::APIEndpoint apiEndpoint, const std::string &eventName) :
-        Event(apiEndpoint, eventName) {}
+        BaseEvent(apiEndpoint, eventName) {}
 };
 
 /**
@@ -40,7 +40,7 @@ class BRANCHIO_DLL_EXPORT SessionOpenEvent : public SessionEvent {
      * @param url Referring link, or an empty string if none.
      * @return this object for chaining builder methods
      */
-    virtual Event& setLinkUrl(const std::string &url) {
+    virtual BaseEvent& setLinkUrl(const std::string &url) {
         if (url.length() > 0) {
             addEventProperty(Defines::JSONKEY_APP_LINK_URL, url);
         }

--- a/BranchSDK/src/BranchIO/LinkInfo.cpp
+++ b/BranchSDK/src/BranchIO/LinkInfo.cpp
@@ -73,7 +73,7 @@ class LinkFallback : public IRequestCallback {
 };
 
 
-LinkInfo::LinkInfo() : Event(Defines::APIEndpoint::URL, "LinkInfo") {
+LinkInfo::LinkInfo() : BaseEvent(Defines::APIEndpoint::URL, "LinkInfo") {
 }
 
 LinkInfo::~LinkInfo() = default;

--- a/BranchSDK/src/BranchIO/LinkInfo.h
+++ b/BranchSDK/src/BranchIO/LinkInfo.h
@@ -5,14 +5,14 @@
 
 #include <string>
 #include "BranchIO/Branch.h"
-#include "BranchIO/Event/Event.h"
+#include "BranchIO/Event/BaseEvent.h"
 
 namespace BranchIO {
 
 /**
  * Link Information.
  */
-class BRANCHIO_DLL_EXPORT LinkInfo : protected Event {
+class BRANCHIO_DLL_EXPORT LinkInfo : protected BaseEvent {
  public:
     /**
      * An Integer value indicating the calculation type of the referral code. In this case,

--- a/BranchSDK/src/BranchIO/Util/RequestManager.cpp
+++ b/BranchSDK/src/BranchIO/Util/RequestManager.cpp
@@ -40,7 +40,7 @@ RequestManager::getDefaultCallback() const {
 }
 
 RequestManager& RequestManager::enqueue(
-    const Event& event,
+    const BaseEvent& event,
     IRequestCallback* callback,
     bool urgent) {
     // Make a copy of the Request on the heap. This will throw if both
@@ -132,7 +132,7 @@ void RequestManager::run() {
 
 RequestManager::RequestTask::RequestTask(
     RequestManager& manager,
-    const Event& event,
+    const BaseEvent& event,
     IRequestCallback* callback) : Poco::Task("request"),
     _manager(manager),
     _event(event),

--- a/BranchSDK/src/BranchIO/Util/RequestManager.h
+++ b/BranchSDK/src/BranchIO/Util/RequestManager.h
@@ -58,7 +58,7 @@ class BRANCHIO_DLL_EXPORT RequestManager : public Poco::Runnable {
      * @throw Poco::InvalidArgumentException if callback and the default callback are both NULL
      */
     RequestManager& enqueue(
-        const Event& event,
+        const BaseEvent& event,
         IRequestCallback* callback = nullptr,
         bool urgent = false);
 
@@ -121,7 +121,7 @@ class BRANCHIO_DLL_EXPORT RequestManager : public Poco::Runnable {
          * @param event Event to send
          * @param callback Interface for success and failure response.
          */
-        RequestTask(RequestManager& manager, const Event& event, IRequestCallback* callback);
+        RequestTask(RequestManager& manager, const BaseEvent& event, IRequestCallback* callback);
 
         // ----- Poco::Task -----
         /**
@@ -146,7 +146,7 @@ class BRANCHIO_DLL_EXPORT RequestManager : public Poco::Runnable {
      private:
         RequestManager& _manager;
         Request _request;
-        Event _event;
+        BaseEvent _event;
         IRequestCallback* _callback;
     };
 


### PR DESCRIPTION
## Reference
SDK-644 -- Create a base event interface

## Description
The C++ SDK development cycle started with Events, and with those events you have the ability to set a number of properties that generally relate to commerce-type events.

Much of the infrastructure that built up allowed anything that was an Event or Event subclass to be placed on the queue, and it knew how to packaged itself up and indicate which endpoint it needed to go to.

The issue here is that there are things that are saying they are Events, while they have no business having commerce type attributes.

This is simply solved by creating a new base (like, "BaseEvent"), and slightly modifying the polymorphism graph correctly.

## Testing Instructions
* Unit Tests Pass
* Samples continue to run correctly

## Risk Assessment [`MEDIUM`]
This was a fairly minor refactor, and none of the samples needed to be changed.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/cppguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
