### PR TITLE
SDK-648 -- example sample issues with missing properties

### DIFF
--- a/BranchSDK-Samples/console/example/example.cpp
+++ b/BranchSDK-Samples/console/example/example.cpp
@@ -209,7 +209,10 @@ protected:
     }
 
     void handleSendInstallEvent(const std::string &name, const std::string &value) {
-        auto branch_link = config().getString(KEY_LINK);
+        std::string branch_link;
+        if (config().has(KEY_LINK)) {
+            branch_link = config().getString(KEY_LINK);
+        }
 
         cout << "handleSendInstallEvent()" << endl;
         _branchInstance->openSession(branch_link, this);


### PR DESCRIPTION
## Reference
SDK-648 -- example sample issues with missing properties

## Description
QA discovered an issue where – if you don't have the branch_link property in the properties file, the sample will crash, and crash hard.

The issue is that the example.properties file that _I_ have been using has a branch_link.   If the properties doesn't have that -- when it tries to access that (missing) property the Application class fails.

## Testing Instructions
1. make sure the example.properties doesn't have a branch_link defined
2. run option #1 or #7 

Test these steps before and after the change

## Risk Assessment [`LOW`]
example sample change only.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/cppguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
