### PR TITLE
SDK-621 -- Release process testing

### DIFF
--- a/BranchSDK-Samples/Windows/ColorPicker/conanfile.txt
+++ b/BranchSDK-Samples/Windows/ColorPicker/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-BranchIO/0.2.0@branch/staging
+BranchIO/0.2.1@branch/staging
 
 [options]
 # master is the default. Uncomment and modify to use a different branch

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,6 +2,12 @@ from conans import ConanFile, CMake, tools
 import os, shutil
 
 class BranchioConan(ConanFile):
+    scm = {
+        "type": "git",
+        "url": "auto",
+        "revision": "auto"
+    }
+
     # ----- Package metadata -----
     name = "BranchIO"
     # TODO(jdee): Set the version in one place and propagate it
@@ -38,36 +44,30 @@ class BranchioConan(ConanFile):
     requires = "Poco/1.9.0@pocoproject/stable"
     build_requires = "gtest/1.8.1@bincrafters/stable"
 
-    scm = {
-        "type": "git",
-        "url": "auto",
-        "revision": "auto"
-    }
-
-    def source(self):
-        if self.options.source_folder:
-            # Install from local source (via rmake)
-            folder = str(self.options.source_folder)
-            self.output.info("Copying from source_folder " + folder)
-            self.copyall(folder, ".", excludes=["build"])
-        elif self.options.git_branch:
-            # Install from a git branch in the repo
-            git = tools.Git(folder=".")
-            self.output.info("Checking out branch %s" % self.options.git_branch)
-
-            # Allow specification of repo URL using BRANCHIO_GIT_URL env. var.
-            git_url_env_var = os.environ.get('BRANCHIO_GIT_URL')
-            git_url = git_url_env_var if git_url_env_var else self.url
-            git.clone(git_url, branch=self.options.git_branch)
-        else:
-            # Install a release from a tag (default)
-            tag_name = "v%s" % self.version
-            self.output.info("Building from tag %s" % tag_name)
-            zip_name = "%s.zip" % tag_name
-            tools.download("%s/archive/%s" % (self.url, zip_name), zip_name)
-            tools.unzip(zip_name)
-            self.copyall("cpp-branch-deep-linking-attribution-%s" % self.version, ".")
-            os.unlink(zip_name)
+# def source(self):
+#     if self.options.source_folder:
+#         # Install from local source (via rmake)
+#         folder = str(self.options.source_folder)
+#         self.output.info("Copying from source_folder " + folder)
+#         self.copyall(folder, ".", excludes=["build"])
+#     elif self.options.git_branch:
+#         # Install from a git branch in the repo
+#         git = tools.Git(folder=".")
+#         self.output.info("Checking out branch %s" % self.options.git_branch)
+#
+#         # Allow specification of repo URL using BRANCHIO_GIT_URL env. var.
+#         git_url_env_var = os.environ.get('BRANCHIO_GIT_URL')
+#         git_url = git_url_env_var if git_url_env_var else self.url
+#         git.clone(git_url, branch=self.options.git_branch)
+#     else:
+#         # Install a release from a tag (default)
+#         tag_name = "v%s" % self.version
+#         self.output.info("Building from tag %s" % tag_name)
+#         zip_name = "%s.zip" % tag_name
+#         tools.download("%s/archive/%s" % (self.url, zip_name), zip_name)
+#         tools.unzip(zip_name)
+#         self.copyall("cpp-branch-deep-linking-attribution-%s" % self.version, ".")
+#         os.unlink(zip_name)
 
     def build(self):
         library_type = "shared" if self.options.shared else "static"

--- a/conanfile.py
+++ b/conanfile.py
@@ -44,31 +44,6 @@ class BranchioConan(ConanFile):
     requires = "Poco/1.9.0@pocoproject/stable"
     build_requires = "gtest/1.8.1@bincrafters/stable"
 
-# def source(self):
-#     if self.options.source_folder:
-#         # Install from local source (via rmake)
-#         folder = str(self.options.source_folder)
-#         self.output.info("Copying from source_folder " + folder)
-#         self.copyall(folder, ".", excludes=["build"])
-#     elif self.options.git_branch:
-#         # Install from a git branch in the repo
-#         git = tools.Git(folder=".")
-#         self.output.info("Checking out branch %s" % self.options.git_branch)
-#
-#         # Allow specification of repo URL using BRANCHIO_GIT_URL env. var.
-#         git_url_env_var = os.environ.get('BRANCHIO_GIT_URL')
-#         git_url = git_url_env_var if git_url_env_var else self.url
-#         git.clone(git_url, branch=self.options.git_branch)
-#     else:
-#         # Install a release from a tag (default)
-#         tag_name = "v%s" % self.version
-#         self.output.info("Building from tag %s" % tag_name)
-#         zip_name = "%s.zip" % tag_name
-#         tools.download("%s/archive/%s" % (self.url, zip_name), zip_name)
-#         tools.unzip(zip_name)
-#         self.copyall("cpp-branch-deep-linking-attribution-%s" % self.version, ".")
-#         os.unlink(zip_name)
-
     def build(self):
         library_type = "shared" if self.options.shared else "static"
         self.output.info("Building %s libraries" % library_type)

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ class BranchioConan(ConanFile):
     # ----- Package metadata -----
     name = "BranchIO"
     # TODO(jdee): Set the version in one place and propagate it
-    version = "0.2.0"
+    version = "0.2.1"
     license = "MIT"
     description = "Branch Metrics deep linking and attribution analytics C++ SDK"
     topics = (
@@ -37,6 +37,12 @@ class BranchioConan(ConanFile):
     # ----- Package dependencies -----
     requires = "Poco/1.9.0@pocoproject/stable"
     build_requires = "gtest/1.8.1@bincrafters/stable"
+
+    scm = {
+        "type": "git",
+        "url": "auto",
+        "revision": "auto"
+    }
 
     def source(self):
         if self.options.source_folder:


### PR DESCRIPTION
## Reference
SDK-621 -- Release 1.0.0 (Testing Release Process)

## Description
This branch is trying to reconcile how to do Conan package management, such that we can use git as our repo for building.

There is some black magic in here, I won't lie.  

The [instructions](https://docs.conan.io/en/latest/creating_packages/package_repo.html#capturing-the-remote-and-commit-scm) say to do this:
```
      scm = {
         "type": "git",  # Use "type": "svn", if local repo is managed using SVN
         "subfolder": "hello",
         "url": "auto",
         "revision": "auto"
      }
```

Our implementation in `conanfile.py` matches those now.
```
    scm = {
        "type": "git",
        "url": "auto",
        "revision": "auto"
    }
```

The resultant package (this one is a little behind, as I've done additional pushes)
```
    scm = {"revision": "7c1e71b525e2b13b30d4de6e634c393cf148ab25",
           "type": "git",
           "url": "https://github.com/BranchMetrics/cpp-branch-deep-linking-attribution"}
```



## Testing Instructions
* Unit Tests Pass
* Windows Color Picker App now picks up the correct package

NOTE:  I tested this against `BranchIO/0.2.1@branch/testing`.   When this gets merged to Staging I will do another Conan push to get `BranchIO/0.2.1@branch/staging`.

## Risk Assessment [`LOW`]
Low, however I am very nervous about removing the previous packaging step

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [x] Conforms to [Style Guides](https://google.github.io/styleguide/cppguide.html)
    - [x] Mission critical pieces are documented in code and out of code as needed.
- [x] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
