### PR TITLE
[INTENG-9716] Update Poco

### DIFF
--- a/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
+++ b/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
@@ -1,7 +1,6 @@
 [requires]
-BranchIO/1.0.0@branch/testing
+BranchIO/1.0.1@branch/testing
 
 [options]
 Poco:enable_mongodb=False
 Poco:enable_data_sqlite=False
-BranchIO:source_folder=../../..

--- a/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
+++ b/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-BranchIO/0.1.0@branch/testing
+BranchIO/1.0.0@branch/testing
 
 [options]
 Poco:enable_mongodb=False

--- a/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
+++ b/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
@@ -4,3 +4,4 @@ BranchIO/1.0.0@branch/testing
 [options]
 Poco:enable_mongodb=False
 Poco:enable_data_sqlite=False
+BranchIO:source_folder=../../..

--- a/BranchSDK/src/BranchIO/Util/RequestManager.cpp
+++ b/BranchSDK/src/BranchIO/Util/RequestManager.cpp
@@ -152,7 +152,7 @@ RequestManager::RequestTask::runTask() {
     if (_manager.getClientSession()) {
         _request.send(_event.getAPIEndpoint(), payload, *_callback, _manager.getClientSession());
     } else {
-        APIClientSession clientSession(BRANCH_IO_URL_BASE);
+        APIClientSession& clientSession(APIClientSession::instance());
         _manager.setClientSession(&clientSession);
         _request.send(_event.getAPIEndpoint(), payload, *_callback, &clientSession);
         _manager.setClientSession(nullptr);

--- a/BranchSDK/src/BranchIO/Util/RequestManager.cpp
+++ b/BranchSDK/src/BranchIO/Util/RequestManager.cpp
@@ -152,7 +152,7 @@ RequestManager::RequestTask::runTask() {
     if (_manager.getClientSession()) {
         _request.send(_event.getAPIEndpoint(), payload, *_callback, _manager.getClientSession());
     } else {
-        APIClientSession& clientSession(APIClientSession::instance());
+        APIClientSession clientSession(BRANCH_IO_URL_BASE);
         _manager.setClientSession(&clientSession);
         _request.send(_event.getAPIEndpoint(), payload, *_callback, &clientSession);
         _manager.setClientSession(nullptr);

--- a/BranchSDK/src/BranchIO/Version.h
+++ b/BranchSDK/src/BranchIO/Version.h
@@ -7,7 +7,7 @@ namespace BranchIO {
 
 #define VERSION_MAJOR               1
 #define VERSION_MINOR               0
-#define VERSION_REVISION            0
+#define VERSION_REVISION            1
 
 }  // namespace BranchIO
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 # TODO(jdee): Set the version in one place and pass it around.
-project(root VERSION 0.2.0 LANGUAGES CXX)
+project(root VERSION 1.0.1 LANGUAGES CXX)
 
 # Determines handling of RPATH and related variables when building dylibs on Mac.
 # TODO(jdee): Review this. RPATH is an issue on Unix right now.

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class BranchioConan(ConanFile):
     # ----- Package metadata -----
     name = "BranchIO"
     # TODO(jdee): Set the version in one place and propagate it
-    version = "1.0.0"
+    version = "1.0.1"
     license = "MIT"
     description = "Branch Metrics deep linking and attribution analytics C++ SDK"
     topics = (
@@ -29,19 +29,19 @@ class BranchioConan(ConanFile):
     )
     author = "Branch Metrics, Inc <sdk-team@branch.io>"
     url = "https://github.com/BranchMetrics/cpp-branch-deep-linking-attribution"
-    # TODO(jdee): Find an appropriate URL for this field, either docs or
-    # marketing.
-    # homepage = "https://docs.branch.io/cpp-sdk"
+    # TODO(jdee): Might not want to call this windows-
+    homepage = "https://help.branch.io/developers-hub/docs/windows-cpp-sdk-overview"
 
     # ----- Package settings and options -----
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "git_branch": "ANY", "source_folder": "ANY"}
-    default_options = {"shared": False, "git_branch": None, "source_folder": None}
+    options = {"shared": [True, False]}
+    default_options = {"shared": False}
     generators = "cmake"
     exports_sources = "BranchIO"
 
     # ----- Package dependencies -----
-    requires = "Poco/1.9.0@pocoproject/stable"
+    # Allow patch updates to Poco
+    requires = "Poco/[~=1.9.4]@pocoproject/stable"
     build_requires = "gtest/1.8.1@bincrafters/stable"
 
     def build(self):

--- a/rmake
+++ b/rmake
@@ -84,7 +84,6 @@ conan create ../.. branch/${Branch2Use} \
   --json conan-install.json \
   --build outdated \
   --options "*:shared=$BUILD_SHARED_LIBS" \
-  --options "BranchIO:source_folder=`pwd`/../.." \
   --options "Poco:enable_mongodb=False" \
   --options "Poco:enable_data_sqlite=False" \
   --settings build_type=$BUILD_TYPE \

--- a/rmake.bat
+++ b/rmake.bat
@@ -156,7 +156,6 @@ conan create ..\.. branch/testing^
   --settings arch=%TARGET_ARCH%^
   --settings compiler.runtime=%RUNTIME%^
   --options *:shared=%BUILD_SHARED_LIBS%^
-  --options BranchIO:source_folder=%CD%\..\..^
   --options Poco:enable_mongodb=False^
   --options Poco:enable_data_sqlite=False^
   --build outdated


### PR DESCRIPTION
## Reference
INTENG-9716

## Description
- Update Poco dependency to 1.9.4. This addresses a consistent SSL failure on Windows.
    The Poco requirement is `[~=1.9.4]`, which permits later patch upgrades via `conan install --update`.
- Update SDK version to 1.0.1.
- Removed some options that are no longer used (`git_branch`, `source_folder`).
- Updated some package metadata (specifically the homepage property to point to help.branch.io).

## Testing Instructions
See me for details.

## Risk Assessment `LOW`

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/cppguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
