### PR TITLE
[SDK-973] Release v 1.0.1

### DIFF
--- a/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
+++ b/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-BranchIO/1.0.1@branch/testing
+BranchIO/1.0.1@branch/stable
 
 [options]
 Poco:enable_mongodb=False

--- a/BranchSDK-Samples/Windows/ColorPicker/conanfile.txt
+++ b/BranchSDK-Samples/Windows/ColorPicker/conanfile.txt
@@ -1,3 +1,6 @@
 [requires]
-BranchIO/1.0.0@branch/stable
+BranchIO/1.0.1@branch/stable
 
+[options]
+Poco:enable_mongodb=False
+Poco:enable_data_sqlite=False

--- a/BranchSDK-Samples/Windows/TestBed/conanfile.txt
+++ b/BranchSDK-Samples/Windows/TestBed/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
-BranchIO/0.0.1@branch/testing
+BranchIO/1.0.1@branch/stable
 
 [options]
-# master is the default. Uncomment and modify to use a different branch
-# BranchIO:git_branch=master
+Poco:enable_mongodb=False
+Poco:enable_data_sqlite=False

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
-# Branch C++ SDK change log
-- v1.0.0
-  * _*Master Release*_ - November 22, 2019
-  * Initial Revision
+2020-05-01  Version 1.0.1
+  * Updated Poco dependency to ~=1.9.4, allowing patch revisions via `conan install --update`.
+    This addresses an HTTPS failure on Windows.
 
+2019-11-22  Version 1.0.0
+  * _*Master Release*_
+  * Initial Revision

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os, shutil
 class BranchioConan(ConanFile):
     scm = {
         "type": "git",
-        "url": "auto",
+        "url": "https://github.com/BranchMetrics/cpp-branch-deep-linking-attribution",
         "revision": "auto"
     }
 


### PR DESCRIPTION
## Reference
SDK-973 -- Release v 1.0.1 of C++ SDK to Conan

## Description
Releasing version 1.0.1 with Poco update to Conan.

## Testing Instructions
This is in our bintray remote now. Add the remote if you don't have it already:

```bash
$ conan remote add branch https://api.bintray.com/conan/branchsdk/cpp-branch-deep-linking-attribution
```

Use `conan remote list` to see currently configured remotes.

You can call the remote whatever you like other than `branch`. In some commands you may specify it by name via `-r branch`. In others all remotes are automatically searched. It's not obvious that v 1.0.0 was ever released to conan-center.

To see it:
```bash
$ conan search -r branch --raw BranchIO/1.0.1@branch/stable
```

To build with it, use this in your conanfile.txt:

```
[requires]
BranchIO/1.0.1@branch/stable

[options]
Poco:enable_mongodb=False
Poco:enable_data_sqlite=False
```

The Poco options are not necessary but recommended to disable unused dependencies.

The easiest way to test on Windows is probably using the BranchDemo app under BranchSDK-Samples/Windows with the Conan Visual Studio Extension.

The process of contributing to conan-center has changed. See https://github.com/conan-io/conan-center-index/wiki. I still need to contact them and request early access. I think the contribution process no longer involves first releasing to our own bintray, but it's still useful to have it there for testing before releasing to conan-center.

## Risk Assessment `LOW`

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/cppguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
