### PR TITLE
[SDK-988] release 1.1.0

### DIFF
--- a/BranchSDK/src/BranchIO/Version.h
+++ b/BranchSDK/src/BranchIO/Version.h
@@ -6,8 +6,8 @@
 namespace BranchIO {
 
 #define VERSION_MAJOR               1
-#define VERSION_MINOR               0
-#define VERSION_REVISION            1
+#define VERSION_MINOR               1
+#define VERSION_REVISION            0
 
 }  // namespace BranchIO
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 # TODO(jdee): Set the version in one place and pass it around.
-project(root VERSION 1.0.1 LANGUAGES CXX)
+project(root VERSION 1.1.0 LANGUAGES CXX)
 
 # Determines handling of RPATH and related variables when building dylibs on Mac.
 # TODO(jdee): Review this. RPATH is an issue on Unix right now.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,26 @@
+2020-05-13  Version 1.1.0
+  * Improvements to thread safety of LinkInfo and its ancestors.
+  * Eliminate queueing and retry of /v1/url requests. A long link will now be
+    generated immediately on any request failure.
+
+  This required some changes to the public interface of `BaseEvent`. The return
+  types of `getCustomData()` and `name()` have changed to avoid returning
+  pointers or references to unsynchronized objects from synchronized getters.
+
+  ```c++
+  BranchIO::JSONObject getCustomData() const;
+  std::string name() const;
+  ```
+
+  In addition, the destructor of `LinkInfo` will now block while any background
+  request is in progress. Once `createUrl()` is called, the `LinkInfo` object
+  is guaranteed to outlive the thread that executes the request. To force
+  immediate termination of the background thread, use `LinkInfo::cancel()`.
+
+  Also note that each `LinkInfo` instance can currently only be used once to
+  generate a URL. For now, create a new `LinkInfo` instance for each URL
+  request. This will be improved in a future release.
+
 2020-05-01  Version 1.0.1
   * Updated Poco dependency to ~=1.9.4, allowing patch revisions via `conan install --update`.
     This addresses an HTTPS failure on Windows.

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class BranchioConan(ConanFile):
     # ----- Package metadata -----
     name = "BranchIO"
     # TODO(jdee): Set the version in one place and propagate it
-    version = "1.0.1"
+    version = "1.1.0"
     license = "MIT"
     description = "Branch Metrics deep linking and attribution analytics C++ SDK"
     topics = (


### PR DESCRIPTION
This is just a manual version bump, since there are some structural issues in the repo that make it hard to automate version update by propagating it with `cmake configure`, and a ChangeLog update.

In a future build, I want to be able to set the version in CMakeLists.txt and then generate conanfile.py and Version.h, but that risks destabilizing things in advance of an important release, so leaving this manual for the moment.