### PR TITLE
Update examples

### DIFF
--- a/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
+++ b/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-BranchIO/1.0.1@branch/stable
+BranchIO/1.1.0@branch/stable
 
 [options]
 Poco:enable_mongodb=False

--- a/BranchSDK-Samples/Windows/ColorPicker/ColorPicker.cpp
+++ b/BranchSDK-Samples/Windows/ColorPicker/ColorPicker.cpp
@@ -360,7 +360,12 @@ class MyOpenCallback : public MyRequestCallback
 
 class MyShareCallback : public MyRequestCallback
 {
-    virtual void onSuccess(int id, BranchIO::JSONObject jsonResponse)
+public:
+    ~MyShareCallback() {
+        _linkInfo.cancel();
+    }
+
+    void onSuccess(int id, BranchIO::JSONObject jsonResponse)
     {
         MyRequestCallback::onSuccess(id, jsonResponse);
 
@@ -371,10 +376,17 @@ class MyShareCallback : public MyRequestCallback
             SetWindowTextA(hwndStatus, url.c_str());
         }
     }
+
+    BranchIO::LinkInfo& linkInfo() {
+        return _linkInfo;
+    }
+
+private:
+    BranchIO::LinkInfo _linkInfo;
 };
 
 BranchIO::IRequestCallback* _branchCallback = new MyRequestCallback();
-BranchIO::IRequestCallback* _shareCallback = new MyShareCallback();
+MyShareCallback* _shareCallback = new MyShareCallback();
 
 void initializeBranch()
 {
@@ -478,7 +490,9 @@ void chooseColor(HWND hwnd)
 
 void shareColor(HWND hwnd)
 {
-    BranchIO::LinkInfo linkInfo;
+    // Create a new LinkInfo each time through. It has to outlive the request,
+    // so can't create it on the stack here.
+    BranchIO::LinkInfo& linkInfo(_shareCallback->linkInfo());
 
     // Note that Windows Colors are backwards (BGR) instead of RGB...
     // Note the use of creating the RGB from BGR here.

--- a/BranchSDK-Samples/Windows/ColorPicker/ColorPicker.cpp
+++ b/BranchSDK-Samples/Windows/ColorPicker/ColorPicker.cpp
@@ -513,6 +513,3 @@ int ColorRefToInt(COLORREF cr) {
     COLORREF crFixup = PALETTERGB(GetBValue(cr), GetGValue(cr), GetRValue(cr));
     return static_cast<int>(crFixup);
 }
-
-
-

--- a/BranchSDK-Samples/Windows/ColorPicker/conanfile.txt
+++ b/BranchSDK-Samples/Windows/ColorPicker/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-BranchIO/1.0.1@branch/stable
+BranchIO/1.1.0@branch/stable
 
 [options]
 Poco:enable_mongodb=False

--- a/BranchSDK-Samples/Windows/TestBed/conanfile.txt
+++ b/BranchSDK-Samples/Windows/TestBed/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-BranchIO/1.0.1@branch/stable
+BranchIO/1.1.0@branch/stable
 
 [options]
 Poco:enable_mongodb=False

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,9 +17,10 @@
   is guaranteed to outlive the thread that executes the request. To force
   immediate termination of the background thread, use `LinkInfo::cancel()`.
 
-  Also note that each `LinkInfo` instance can currently only be used once to
+  ~~Also note that each `LinkInfo` instance can currently only be used once to
   generate a URL. For now, create a new `LinkInfo` instance for each URL
-  request. This will be improved in a future release.
+  request. This will be improved in a future release.~~ Each 'LinkInfo' instance
+  is reusable.
 
 2020-05-01  Version 1.0.1
   * Updated Poco dependency to ~=1.9.4, allowing patch revisions via `conan install --update`.


### PR DESCRIPTION
This updates the Windows examples to use 1.1.0 from Conan. It also updates the ColorPicker app with a recommended way to use LinkInfo.

Also corrects the incorrect remark in the ChangeLog that LinkInfo instances cannot be reused.

The TestBed app at the moment may or may not build.