### PR TITLE
[SDK-1028] Wide string support for Windows (inbound)

### DIFF
--- a/BranchSDK/src/BranchIO/AppInfo.cpp
+++ b/BranchSDK/src/BranchIO/AppInfo.cpp
@@ -20,23 +20,23 @@ AppInfo::~AppInfo() {
 }
 
 AppInfo&
-AppInfo::setAppVersion(const std::string &appVersion) {
-    return doAddProperty(Defines::JSONKEY_APP_VERSION, appVersion);
+AppInfo::setAppVersion(const String& appVersion) {
+    return doAddProperty(Defines::JSONKEY_APP_VERSION, appVersion.str());
 }
 
 AppInfo&
-AppInfo::setDeveloperIdentity(const std::string &identity) {
-    return doAddProperty(Defines::JSONKEY_APP_DEVELOPER_IDENTITY, identity);
+AppInfo::setDeveloperIdentity(const String& identity) {
+    return doAddProperty(Defines::JSONKEY_APP_DEVELOPER_IDENTITY, identity.str());
 }
 
 AppInfo&
-AppInfo::setEnvironment(const std::string &environment) {
-    return doAddProperty(Defines::JSONKEY_APP_ENVIRONMENT, environment);
+AppInfo::setEnvironment(const String& environment) {
+    return doAddProperty(Defines::JSONKEY_APP_ENVIRONMENT, environment.str());
 }
 
 AppInfo&
-AppInfo::setCountryCode(const std::string &countryCode) {
-    return doAddProperty(Defines::JSONKEY_DEVICE_COUNTRY, countryCode);
+AppInfo::setCountryCode(const String& countryCode) {
+    return doAddProperty(Defines::JSONKEY_DEVICE_COUNTRY, countryCode.str());
 }
 
 AppInfo&
@@ -49,13 +49,13 @@ AppInfo::setDisplayInfo(int dpi, int width, int height) {
 }
 
 AppInfo&
-AppInfo::setLanguage(const std::string &language) {
-    return doAddProperty(Defines::JSONKEY_DEVICE_LANGUAGE, language);
+AppInfo::setLanguage(const String& language) {
+    return doAddProperty(Defines::JSONKEY_DEVICE_LANGUAGE, language.str());
 }
 
 AppInfo&
-AppInfo::setPackageName(const std::string &packageName) {
-    return doAddProperty(Defines::JSONKEY_APP_PACKAGE_NAME, packageName);
+AppInfo::setPackageName(const String& packageName) {
+    return doAddProperty(Defines::JSONKEY_APP_PACKAGE_NAME, packageName.str());
 }
 
 std::string

--- a/BranchSDK/src/BranchIO/AppInfo.h
+++ b/BranchSDK/src/BranchIO/AppInfo.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include "BranchIO/PropertyManager.h"
+#include "BranchIO/String.h"
 
 namespace BranchIO {
 
@@ -32,7 +33,7 @@ class BRANCHIO_DLL_EXPORT AppInfo : public PropertyManager {
      * @return This object for chaining builder methods
      * @todo(andyp): Example
      */
-    AppInfo& setAppVersion(const std::string &appVersion);
+    AppInfo& setAppVersion(const String& appVersion);
 
     /**
      * Set the device country code.
@@ -40,7 +41,7 @@ class BRANCHIO_DLL_EXPORT AppInfo : public PropertyManager {
      * @return This object for chaining builder methods
      * @todo(andyp): Example
      */
-    AppInfo& setCountryCode(const std::string &countryCode);
+    AppInfo& setCountryCode(const String& countryCode);
 
     /**
      * Set the Developer Identity.
@@ -49,7 +50,7 @@ class BRANCHIO_DLL_EXPORT AppInfo : public PropertyManager {
      * @param identity Unique User id.  Example: "steve"
      * @return This object for chaining builder methods
      */
-    AppInfo& setDeveloperIdentity(const std::string &identity);
+    AppInfo& setDeveloperIdentity(const String& identity);
 
     /**
      * Set the Display information.
@@ -66,7 +67,7 @@ class BRANCHIO_DLL_EXPORT AppInfo : public PropertyManager {
      * @return This object for chaining builder methods
      * @todo(andyp): What is this
      */
-    AppInfo& setEnvironment(const std::string &environment);
+    AppInfo& setEnvironment(const String& environment);
 
     /**
      * Set the Device Language.
@@ -74,14 +75,14 @@ class BRANCHIO_DLL_EXPORT AppInfo : public PropertyManager {
      * @return This object for chaining builder methods
      * @todo(andyp): Example
      */
-    AppInfo& setLanguage(const std::string &language);
+    AppInfo& setLanguage(const String& language);
 
     /**
      * Set the Package name of the application.
      * @param packageName Package Name
      * @return This object for chaining builder methods
      */
-    AppInfo& setPackageName(const std::string &packageName);
+    AppInfo& setPackageName(const String& packageName);
 
     /**
      * Get the developer identity

--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -46,6 +46,8 @@ class BranchWindows : public Branch {
 
 #endif
 
+using namespace std;
+
 /**
  * (Internal) Session Callback.
  * This class maintains the state of the IPackagingInfo Session
@@ -109,7 +111,7 @@ class SessionCallback : public IRequestCallback {
     IRequestCallback *_parentCallback;
 };
 
-Branch *Branch::create(const std::string &branchKey, AppInfo *pInfo) {
+Branch *Branch::create(const String& branchKey, AppInfo* pInfo) {
     Branch *instance = nullptr;
 #if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
     instance = new BranchUnix();
@@ -135,7 +137,7 @@ Branch *Branch::create(const std::string &branchKey, AppInfo *pInfo) {
         instance->_packagingInfo.getAppInfo().addProperties(pInfo->toJSON());
     }
 
-    instance->_packagingInfo.setBranchKey(branchKey);
+    instance->_packagingInfo.setBranchKey(branchKey.str());
 
     instance->_requestManager = new RequestManager(instance->_packagingInfo);
     instance->_requestManager->start();
@@ -149,12 +151,13 @@ Branch::~Branch() {
 }
 
 void
-Branch::openSession(const std::string &linkUrl, IRequestCallback *callback) {
+Branch::openSession(const String& linkUrl, IRequestCallback* callback) {
     SessionCallback *sessionCallback = new SessionCallback(&_packagingInfo, callback);
     SessionOpenEvent event;
 
-    if (linkUrl.length() > 0) {
-        event.setLinkUrl(linkUrl);
+    string sLinkUrl(linkUrl.str());
+    if (sLinkUrl.length() > 0) {
+        event.setLinkUrl(sLinkUrl);
     }
 
     sendEvent(event, sessionCallback);
@@ -181,9 +184,9 @@ Branch::sendEvent(const BaseEvent &event, IRequestCallback *callback) {
 }
 
 void
-Branch::setIdentity(const std::string& userId, IRequestCallback *callback) {
+Branch::setIdentity(const String& userId, IRequestCallback* callback) {
     if (getSessionInfo().hasSessionId()) {
-        IdentityLoginEvent event(userId);
+        IdentityLoginEvent event(userId.str());
         sendEvent(event, callback);
     } else {
         if (callback) {

--- a/BranchSDK/src/BranchIO/Branch.h
+++ b/BranchSDK/src/BranchIO/Branch.h
@@ -15,6 +15,7 @@
 #include "BranchIO/PackagingInfo.h"
 #include "BranchIO/IRequestCallback.h"
 #include "BranchIO/SessionInfo.h"
+#include "BranchIO/String.h"
 
 namespace BranchIO {
 
@@ -41,9 +42,7 @@ class BRANCHIO_DLL_EXPORT Branch {
      * @param pInfo Application Information.
      * @return a new instance of Branch
      */
-    static Branch *create(
-        const std::string &branchKey,
-        AppInfo *pInfo);
+    static Branch *create(const String& branchKey, AppInfo* pInfo);
 
     /**
      * Destructor.
@@ -55,7 +54,7 @@ class BRANCHIO_DLL_EXPORT Branch {
      * @param linkUrl Referring link, or an empty string if none.
      * @param callback Callback to fire with success or failure notification.
      */
-    virtual void openSession(const std::string &linkUrl = "", IRequestCallback *callback = nullptr);
+    virtual void openSession(const String& linkUrl = "", IRequestCallback* callback = nullptr);
 
     /**
      * Close a Branch Session.
@@ -114,7 +113,7 @@ class BRANCHIO_DLL_EXPORT Branch {
      * @param userId   A value containing the unique identifier of the user.
      * @param callback Callback to fire with success or failure notification.
      */
-    void setIdentity(const std::string& userId, IRequestCallback *callback);
+    void setIdentity(const String& userId, IRequestCallback* callback);
 
     /**
      * This method should be called if you know that a different person is about to use the app. For example,

--- a/BranchSDK/src/BranchIO/Event/BaseEvent.cpp
+++ b/BranchSDK/src/BranchIO/Event/BaseEvent.cpp
@@ -21,9 +21,9 @@ static const char *JSONKEY_USER_DATA = "user_data";
 static const char *JSONKEY_BRANCH_KEY = "branch_key";
 static const char *JSONKEY_ADVERTISING_IDS = "advertising_ids";
 
-BaseEvent::BaseEvent(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr) :
+BaseEvent::BaseEvent(Defines::APIEndpoint apiEndpoint, const String& eventName, JSONObject::Ptr jsonPtr) :
     mAPIEndpoint(apiEndpoint),
-    mEventName(eventName) {
+    mEventName(eventName.str()) {
 
     if (jsonPtr.get()) {
         // Copy the key/values
@@ -43,7 +43,7 @@ BaseEvent::BaseEvent(const BaseEvent &other) :
 BaseEvent::~BaseEvent() = default;
 
 BaseEvent&
-BaseEvent::addEventProperty(const char *propertyName, const std::string &propertyValue) {
+BaseEvent::addEventProperty(const char *propertyName, const String& propertyValue) {
     addProperty(propertyName, propertyValue);
     return *this;
 }
@@ -55,9 +55,9 @@ BaseEvent::addEventProperty(const char *propertyName, double propertyValue) {
 }
 
 BaseEvent&
-BaseEvent::addCustomDataProperty(const std::string &propertyName, const std::string &propertyValue) {
+BaseEvent::addCustomDataProperty(const String &propertyName, const String &propertyValue) {
     Mutex::ScopedLock _l(mMutex);
-    mCustomData.set(propertyName, propertyValue);
+    mCustomData.set(propertyName.str(), propertyValue.str());
     return *this;
 }
 

--- a/BranchSDK/src/BranchIO/Event/BaseEvent.h
+++ b/BranchSDK/src/BranchIO/Event/BaseEvent.h
@@ -39,7 +39,7 @@ class BRANCHIO_DLL_EXPORT BaseEvent : public PropertyManager {
      * @param propertyValue Value of the custom property
      * @return This object for chaining builder methods
      */
-    virtual BaseEvent& addCustomDataProperty(const std::string &propertyName, const std::string &propertyValue);
+    virtual BaseEvent& addCustomDataProperty(const String &propertyName, const String &propertyValue);
 
     /**
      * Get the custom data properties associated with this Branch Event.
@@ -68,7 +68,7 @@ class BRANCHIO_DLL_EXPORT BaseEvent : public PropertyManager {
      * @param eventName The "Name" of the event
      * @param jsonPtr Base JSON to start with
      */
-    BaseEvent(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr = nullptr);
+    BaseEvent(Defines::APIEndpoint apiEndpoint, const String& eventName, JSONObject::Ptr jsonPtr = nullptr);
 
     /**
      * Add a Raw Event Property Name and Value
@@ -76,7 +76,7 @@ class BRANCHIO_DLL_EXPORT BaseEvent : public PropertyManager {
      * @param propertyValue Property Value
      * @return this object for chaining builder methods
      */
-    BaseEvent& addEventProperty(const char *propertyName, const std::string &propertyValue);
+    BaseEvent& addEventProperty(const char *propertyName, const String& propertyValue);
 
     /**
      * Add a Raw Event Property Name and Value

--- a/BranchSDK/src/BranchIO/Event/CustomEvent.cpp
+++ b/BranchSDK/src/BranchIO/Event/CustomEvent.cpp
@@ -5,7 +5,7 @@
 
 namespace BranchIO {
 
-CustomEvent::CustomEvent(const std::string &eventName) :
+CustomEvent::CustomEvent(const String& eventName) :
     Event(Defines::APIEndpoint::TRACK_CUSTOM_EVENT, eventName) { }
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/Event/CustomEvent.h
+++ b/BranchSDK/src/BranchIO/Event/CustomEvent.h
@@ -20,7 +20,7 @@ class BRANCHIO_DLL_EXPORT CustomEvent : public Event {
      * Event names that match Standard Events will be treated as Standard Events.
      * @param eventName Custom Event Name.
      */
-    explicit CustomEvent(const std::string &eventName);
+    explicit CustomEvent(const String &eventName);
 };
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/Event/Event.cpp
+++ b/BranchSDK/src/BranchIO/Event/Event.cpp
@@ -3,6 +3,7 @@
 #include "Event.h"
 #include "BranchIO/Defines.h"
 #include "BranchIO/JSONObject.h"
+#include "BranchIO/String.h"
 
 namespace BranchIO {
 
@@ -12,7 +13,7 @@ const char *AD_TYPE_INTERSTITIAL = "INTERSTITIAL";
 const char *AD_TYPE_REWARDED_VIDEO = "REWARDED_VIDEO";
 const char *AD_TYPE_NATIVE = "NATIVE";
 
-Event::Event(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr) :
+Event::Event(Defines::APIEndpoint apiEndpoint, const String& eventName, JSONObject::Ptr jsonPtr) :
     BaseEvent(apiEndpoint, eventName, jsonPtr) {
 }
 
@@ -29,13 +30,13 @@ Event::setAdType(Event::AdType adType) {
 }
 
 Event&
-Event::setAffiliation(const std::string &affiliation) {
+Event::setAffiliation(const String& affiliation) {
     addEventProperty(Defines::JSONKEY_AFFILIATION, affiliation);
     return *this;
 }
 
 Event&
-Event::setCoupon(const std::string &coupon) {
+Event::setCoupon(const String& coupon) {
     addEventProperty(Defines::JSONKEY_COUPON, coupon);
     return *this;
 }
@@ -47,13 +48,13 @@ Event::setCurrency(const CurrencyType &currency) {
 }
 
 Event&
-Event::setCustomerEventAlias(const std::string &alias) {
+Event::setCustomerEventAlias(const String& alias) {
     addEventProperty(Defines::JSONKEY_CUSTOMER_EVENT_ALIAS, alias);
     return *this;
 }
 
 Event&
-Event::setDescription(const std::string &description) {
+Event::setDescription(const String& description) {
     addEventProperty(Defines::JSONKEY_DESCRIPTION, description);
     return *this;
 }
@@ -65,7 +66,7 @@ Event::setRevenue(double revenue) {
 }
 
 Event&
-Event::setSearchQuery(const std::string &searchQuery) {
+Event::setSearchQuery(const String& searchQuery) {
     addEventProperty(Defines::JSONKEY_SEARCHQUERY, searchQuery);
     return *this;
 }
@@ -83,7 +84,7 @@ Event::setTax(double tax) {
 }
 
 Event&
-Event::setTransactionId(const std::string &transactionId) {
+Event::setTransactionId(const String& transactionId) {
     addEventProperty(Defines::JSONKEY_TRANSACTION_ID, transactionId);
     return *this;
 }

--- a/BranchSDK/src/BranchIO/Event/Event.h
+++ b/BranchSDK/src/BranchIO/Event/Event.h
@@ -47,14 +47,14 @@ class BRANCHIO_DLL_EXPORT Event : public BaseEvent {
      * @param affiliation Any affiliation value
      * @return This object for chaining builder methods
      */
-    virtual Event& setAffiliation(const std::string &affiliation);
+    virtual Event& setAffiliation(const String &affiliation);
 
     /**
      * Set any coupons associated with this transaction event.
      * @param coupon Any coupon value
      * @return This object for chaining builder methods
      */
-    virtual Event& setCoupon(const std::string &coupon);
+    virtual Event& setCoupon(const String &coupon);
 
     /**
      * Set the currency related with this transaction event.
@@ -68,14 +68,14 @@ class BRANCHIO_DLL_EXPORT Event : public BaseEvent {
      * @param alias Customer Event Alias.
      * @return This object for chaining builder methods
      */
-    virtual Event& setCustomerEventAlias(const std::string &alias);
+    virtual Event& setCustomerEventAlias(const String &alias);
 
     /**
      * Set description for this transaction event.
      * @param description transaction description
      * @return This object for chaining builder methods
      */
-    virtual Event& setDescription(const std::string &description);
+    virtual Event& setDescription(const String &description);
 
     /**
      * Set the revenue value  related with this transaction event.
@@ -89,7 +89,7 @@ class BRANCHIO_DLL_EXPORT Event : public BaseEvent {
      * @param searchQuery Search Query value
      * @return This object for chaining builder methods
      */
-    virtual Event& setSearchQuery(const std::string &searchQuery);
+    virtual Event& setSearchQuery(const String &searchQuery);
 
     /**
      * Set the shipping value  related with this transaction event.
@@ -110,7 +110,7 @@ class BRANCHIO_DLL_EXPORT Event : public BaseEvent {
      * @param transactionId Transaction Id
      * @return this object for chaining builder methods
      */
-    virtual Event& setTransactionId(const std::string &transactionId);
+    virtual Event& setTransactionId(const String& transactionId);
 
     using PropertyManager::toString;
 
@@ -121,7 +121,7 @@ class BRANCHIO_DLL_EXPORT Event : public BaseEvent {
      * @param eventName The "Name" of the event
      * @param jsonPtr Base JSON to start with
      */
-    Event(Defines::APIEndpoint apiEndpoint, const std::string &eventName, JSONObject::Ptr jsonPtr = nullptr);
+    Event(Defines::APIEndpoint apiEndpoint, const String& eventName, JSONObject::Ptr jsonPtr = nullptr);
 
  private:
     Event();

--- a/BranchSDK/src/BranchIO/Event/IdentityEvent.h
+++ b/BranchSDK/src/BranchIO/Event/IdentityEvent.h
@@ -19,7 +19,7 @@ class BRANCHIO_DLL_EXPORT IdentityEvent : public BaseEvent {
      * @param apiEndpoint API endpoint
      * @param eventName Event Name
      */
-    IdentityEvent(Defines::APIEndpoint apiEndpoint, const std::string &eventName) :
+    IdentityEvent(Defines::APIEndpoint apiEndpoint, const String& eventName) :
         BaseEvent(apiEndpoint, eventName) {}
 };
 
@@ -32,7 +32,7 @@ class BRANCHIO_DLL_EXPORT IdentityLoginEvent : public IdentityEvent {
      * Constructor.
      * @param identity A value containing the unique identifier of the user
      */
-    IdentityLoginEvent(std::string identity) :
+    IdentityLoginEvent(const String& identity) :
             IdentityEvent(Defines::APIEndpoint::IDENTIFY_USER, "setIdentity") {
 
         addEventProperty(Defines::JSONKEY_APP_IDENTITY, identity);

--- a/BranchSDK/src/BranchIO/Event/SessionEvent.h
+++ b/BranchSDK/src/BranchIO/Event/SessionEvent.h
@@ -20,7 +20,7 @@ class BRANCHIO_DLL_EXPORT SessionEvent : public BaseEvent {
      * @param apiEndpoint API endpoint
      * @param eventName Event Name
      */
-    SessionEvent(Defines::APIEndpoint apiEndpoint, const std::string &eventName) :
+    SessionEvent(Defines::APIEndpoint apiEndpoint, const String& eventName) :
         BaseEvent(apiEndpoint, eventName) {}
 };
 
@@ -40,8 +40,8 @@ class BRANCHIO_DLL_EXPORT SessionOpenEvent : public SessionEvent {
      * @param url Referring link, or an empty string if none.
      * @return this object for chaining builder methods
      */
-    virtual BaseEvent& setLinkUrl(const std::string &url) {
-        if (url.length() > 0) {
+    virtual BaseEvent& setLinkUrl(const String &url) {
+        if (url.str().length() > 0) {
             addEventProperty(Defines::JSONKEY_APP_LINK_URL, url);
         }
         return *this;

--- a/BranchSDK/src/BranchIO/Event/StandardEvent.cpp
+++ b/BranchSDK/src/BranchIO/Event/StandardEvent.cpp
@@ -2,6 +2,7 @@
 
 #include "BranchIO/Event/StandardEvent.h"
 #include "BranchIO/Defines.h"
+#include "BranchIO/String.h"
 
 namespace BranchIO {
 

--- a/BranchSDK/src/BranchIO/Event/StandardEvent.h
+++ b/BranchSDK/src/BranchIO/Event/StandardEvent.h
@@ -47,6 +47,7 @@ class BRANCHIO_DLL_EXPORT StandardEvent : public Event {
         CLICK_AD,                       ///< Click Ad Event
         VIEW_AD                         ///< View Ad Event
     } Type;
+
     /**
      * Convert a StandardEvent to a String
      * @param eventType event type

--- a/BranchSDK/src/BranchIO/LinkInfo.cpp
+++ b/BranchSDK/src/BranchIO/LinkInfo.cpp
@@ -106,40 +106,40 @@ LinkInfo::getBranchInstance() const {
 }
 
 LinkInfo &
-LinkInfo::addControlParameter(const char *key, const std::string &value) {
+LinkInfo::addControlParameter(const String& key, const String& value) {
     Mutex::ScopedLock _l(_mutex);
-    _controlParams.addProperty(key, value);
+    _controlParams.addProperty(key.str().c_str(), value.str());
     addProperty(JSONKEY_DATA, _controlParams);
     return *this;
 }
 
 LinkInfo &
-LinkInfo::addControlParameter(const char *key, int value) {
+LinkInfo::addControlParameter(const String& key, int value) {
     Mutex::ScopedLock _l(_mutex);
-    _controlParams.addProperty(key, value);
+    _controlParams.addProperty(key.str().c_str(), value);
     addProperty(JSONKEY_DATA, _controlParams);
     return *this;
 }
 
 LinkInfo&
-LinkInfo::addControlParameter(const char *key, const PropertyManager &value) {
+LinkInfo::addControlParameter(const String& key, const PropertyManager& value) {
     Mutex::ScopedLock _l(_mutex);
-    _controlParams.addProperty(key, value);
+    _controlParams.addProperty(key.str().c_str(), value);
     addProperty(JSONKEY_DATA, _controlParams);
     return *this;
 }
 
 LinkInfo&
-LinkInfo::addTag(const std::string &tag) {
+LinkInfo::addTag(const String& tag) {
     Mutex::ScopedLock _l(_mutex);
-    _tagParams.add(tag);
+    _tagParams.add(tag.str());
     addProperty(JSONKEY_TAGS, _tagParams);
     return *this;
 }
 
 LinkInfo&
-LinkInfo::setAlias(const std::string &alias) {
-    return doAddProperty(JSONKEY_ALIAS, alias);
+LinkInfo::setAlias(const String& alias) {
+    return doAddProperty(JSONKEY_ALIAS, alias.str());
 }
 
 std::string
@@ -148,8 +148,8 @@ LinkInfo::getAlias() const {
 }
 
 LinkInfo &
-LinkInfo::setCampaign(const std::string &campaign) {
-    return doAddProperty(JSONKEY_CAMPAIGN, campaign);
+LinkInfo::setCampaign(const String& campaign) {
+    return doAddProperty(JSONKEY_CAMPAIGN, campaign.str());
 }
 
 std::string
@@ -158,8 +158,8 @@ LinkInfo::getCampaign() const {
 }
 
 LinkInfo &
-LinkInfo::setChannel(const std::string &channel) {
-    return doAddProperty(JSONKEY_CHANNEL, channel);
+LinkInfo::setChannel(const String& channel) {
+    return doAddProperty(JSONKEY_CHANNEL, channel.str());
 }
 
 std::string
@@ -173,8 +173,8 @@ LinkInfo::setDuration(int duration) {
 }
 
 LinkInfo &
-LinkInfo::setFeature(const std::string &feature) {
-    return doAddProperty(JSONKEY_FEATURE, feature);
+LinkInfo::setFeature(const String& feature) {
+    return doAddProperty(JSONKEY_FEATURE, feature.str());
 }
 
 std::string
@@ -183,8 +183,8 @@ LinkInfo::getFeature() const {
 }
 
 LinkInfo &
-LinkInfo::setStage(const std::string &stage) {
-    return doAddProperty(JSONKEY_STAGE, stage);
+LinkInfo::setStage(const String& stage) {
+    return doAddProperty(JSONKEY_STAGE, stage.str());
 }
 
 std::string
@@ -224,13 +224,14 @@ LinkInfo::createUrl(Branch *branchInstance, IRequestCallback *callback) {
 }
 
 std::string
-LinkInfo::createLongUrl(Branch *branchInstance, const std::string &baseUrl) const {
+LinkInfo::createLongUrl(Branch* branchInstance, const String& baseUrl) const {
     Mutex::ScopedLock _l(_mutex);
 
     // TODO(andyp): Handle response from setIdentity if there is a base URL in the response
 
     string longUrl;
-    longUrl += (baseUrl.size() > 0 ? baseUrl : BASE_LONG_URL);
+    string sBaseUrl(baseUrl.str());
+    longUrl += (sBaseUrl.size() > 0 ? sBaseUrl : BASE_LONG_URL);
     longUrl += branchInstance->getBranchKey();
 
     Poco::URI uri(longUrl);

--- a/BranchSDK/src/BranchIO/LinkInfo.h
+++ b/BranchSDK/src/BranchIO/LinkInfo.h
@@ -10,6 +10,7 @@
 #include "BranchIO/Event/BaseEvent.h"
 #include "BranchIO/IRequestCallback.h"
 #include "BranchIO/fwd.h"
+#include "BranchIO/String.h"
 
 namespace BranchIO {
 
@@ -51,7 +52,7 @@ class BRANCHIO_DLL_EXPORT LinkInfo :
      * @param value A string with the value for the parameter
      * @return This object for chaining builder methods
      */
-    LinkInfo& addControlParameter(const char *key, const std::string &value);
+    LinkInfo& addControlParameter(const String& key, const String &value);
 
     /**
      * Any other params to be added; you can define your own.
@@ -60,7 +61,7 @@ class BRANCHIO_DLL_EXPORT LinkInfo :
      * @param value An integer with the value for the parameter
      * @return This object for chaining builder methods
      */
-    LinkInfo& addControlParameter(const char *key, int value);
+    LinkInfo& addControlParameter(const String& key, int value);
 
     /**
      * Any other params to be added; you can define your own.
@@ -69,7 +70,7 @@ class BRANCHIO_DLL_EXPORT LinkInfo :
      * @param value A PropertyManager with the value for the parameter
      * @return This object for chaining builder methods
      */
-    LinkInfo& addControlParameter(const char *key, const PropertyManager &value);
+    LinkInfo& addControlParameter(const String& key, const PropertyManager& value);
 
     /**
      * Adds a tag to the collection associated with a deep link.
@@ -77,7 +78,7 @@ class BRANCHIO_DLL_EXPORT LinkInfo :
      * @param tag A tag associated with a deep link.
      * @return This object for chaining builder methods
      */
-    LinkInfo& addTag(const std::string &tag);
+    LinkInfo& addTag(const String& tag);
 
     /**
      * Sets the alias for this link.
@@ -85,7 +86,7 @@ class BRANCHIO_DLL_EXPORT LinkInfo :
      * @param alias A string value containing the desired alias name to add.
      * @return This object for chaining builder methods
      */
-    LinkInfo& setAlias(const std::string &alias);
+    LinkInfo& setAlias(const String& alias);
 
     /**
      * A string value that represents the campaign associated with this link.
@@ -93,7 +94,7 @@ class BRANCHIO_DLL_EXPORT LinkInfo :
      * @param campaign A string value specifying the campaign.
      * @return This object for chaining builder methods
      */
-    LinkInfo& setCampaign(const std::string &campaign);
+    LinkInfo& setCampaign(const String& campaign);
 
     /**
      * [Optional] The channel in which the link will be shared. eg: "facebook",
@@ -103,7 +104,7 @@ class BRANCHIO_DLL_EXPORT LinkInfo :
      *                belongs to. (max 128 characters).
      * @return This object for chaining builder methods
      */
-    LinkInfo& setChannel(const std::string &channel);
+    LinkInfo& setChannel(const String& channel);
 
     /**
      * [Optional] You can set the duration manually. This is the time that
@@ -122,7 +123,7 @@ class BRANCHIO_DLL_EXPORT LinkInfo :
      * @param feature A string specifying the feature. (max 128 characters).
      * @return This object for chaining builder methods
      */
-    LinkInfo& setFeature(const std::string &feature);
+    LinkInfo& setFeature(const String &feature);
 
     /**
      * A string value that represents the stage of the user in the app. eg:
@@ -131,7 +132,7 @@ class BRANCHIO_DLL_EXPORT LinkInfo :
      * @param stage A string value specifying the stage.
      * @return This object for chaining builder methods
      */
-    LinkInfo& setStage(const std::string &stage);
+    LinkInfo& setStage(const String &stage);
 
     /**
      * Adds a type to the link.
@@ -161,7 +162,7 @@ class BRANCHIO_DLL_EXPORT LinkInfo :
      * @param baseUrl Non-Default base to use for forming the url
      * @return A url with the given deep link parameters.
      */
-    std::string createLongUrl(Branch *branchInstance, const std::string &baseUrl = "") const;
+    std::string createLongUrl(Branch* branchInstance, const String& baseUrl = String()) const;
 
     using PropertyManager::toString;
 
@@ -241,7 +242,7 @@ class BRANCHIO_DLL_EXPORT LinkInfo :
      * @param value Key value
      * @return This object for chaining builder methods
      */
-    LinkInfo& doAddProperty(const char *name, const std::string &value);
+    LinkInfo& doAddProperty(const char *name, const std::string& value);
 
     /**
      * Add an int value property to the set.

--- a/BranchSDK/src/BranchIO/PropertyManager.cpp
+++ b/BranchSDK/src/BranchIO/PropertyManager.cpp
@@ -3,8 +3,10 @@
 #include "BranchIO/PropertyManager.h"
 #include "BranchIO/JSONObject.h"
 #include "BranchIO/Util/Storage.h"
+#include "BranchIO/String.h"
 
 using namespace Poco;
+using namespace std;
 
 namespace BranchIO {
 
@@ -27,46 +29,48 @@ PropertyManager::operator=(const PropertyManager& other) {
 PropertyManager::~PropertyManager() = default;
 
 PropertyManager&
-PropertyManager::addProperty(const char *name, const std::string &value) {
+PropertyManager::addProperty(const String& name, const String& value) {
     Mutex::ScopedLock _l(_mutex);
 
-    if (value.length() == 0) {
-        remove(name);
+    string utf8Name(name.str());
+    string utf8Val(value.str());
+    if (value.str().length() == 0) {
+        remove(utf8Name);
     } else {
-        set(name, value);
+        set(utf8Name, utf8Val);
     }
     return *this;
 }
 
 PropertyManager&
-PropertyManager::addProperty(const char *name, int value) {
+PropertyManager::addProperty(const String& name, int value) {
     Mutex::ScopedLock _l(_mutex);
 
-    set(name, value);
+    set(name.str(), value);
     return *this;
 }
 
 PropertyManager&
-PropertyManager::addProperty(const char *name, double value) {
+PropertyManager::addProperty(const String& name, double value) {
     Mutex::ScopedLock _l(_mutex);
 
-    set(name, value);
+    set(name.str(), value);
     return *this;
 }
 
 PropertyManager&
-PropertyManager::addProperty(const char *name, const PropertyManager &value) {
+PropertyManager::addProperty(const String& name, const PropertyManager &value) {
     Mutex::ScopedLock _l(_mutex);
 
-    set(name, value);
+    set(name.str(), value);
     return *this;
 }
 
 PropertyManager&
-PropertyManager::addProperty(const char *name, const Poco::JSON::Array &value) {
+PropertyManager::addProperty(const String& name, const Poco::JSON::Array &value) {
     Mutex::ScopedLock _l(_mutex);
 
-    set(name, value);
+    set(name.str(), value);
     return *this;
 }
 

--- a/BranchSDK/src/BranchIO/PropertyManager.h
+++ b/BranchSDK/src/BranchIO/PropertyManager.h
@@ -10,6 +10,7 @@
 #include "BranchIO/Util/IStringConvertible.h"
 #include "BranchIO/JSONObject.h"
 #include "BranchIO/JSONArray.h"
+#include "BranchIO/String.h"
 
 namespace BranchIO {
 
@@ -58,6 +59,10 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
      */
     virtual JSONObject toJSON() const;
 
+    /*
+     * TODO(@jdee): Replace these methods with a specialized template
+     */
+
     /**
      * Add a string value property to the set.
      * Note that if the value is empty, this effectively removes the key.
@@ -65,7 +70,7 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
      * @param value Key value
      * @return This object for chaining builder methods
      */
-    virtual PropertyManager& addProperty(const char *name, const std::string &value);
+    virtual PropertyManager& addProperty(const String& name, const String& value);
 
     /**
      * Add a int value property to the set.
@@ -73,7 +78,7 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
      * @param value Key value
      * @return This object for chaining builder methods
      */
-    virtual PropertyManager& addProperty(const char *name, int value);
+    virtual PropertyManager& addProperty(const String& name, int value);
 
     /**
      * Add a double value property to the set.
@@ -81,7 +86,7 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
      * @param value Key value
      * @return This object for chaining builder methods
      */
-    virtual PropertyManager& addProperty(const char *name, double value);
+    virtual PropertyManager& addProperty(const String& name, double value);
 
     /**
      * Add Properties from an existing PropertyManager.
@@ -89,7 +94,7 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
      * @param value Key value
      * @return This object for chaining builder methods
      */
-    virtual PropertyManager& addProperty(const char *name, const PropertyManager &value);
+    virtual PropertyManager& addProperty(const String& name, const PropertyManager &value);
 
     /**
      * Add a JSON Array value property to the set.
@@ -98,7 +103,7 @@ class BRANCHIO_DLL_EXPORT PropertyManager : protected JSONObject, public virtual
      * @param value Key value
      * @return This object for chaining builder methods
      */
-    virtual PropertyManager& addProperty(const char *name, const Poco::JSON::Array &value);
+    virtual PropertyManager& addProperty(const String& name, const Poco::JSON::Array &value);
 
 
     /**

--- a/BranchSDK/src/BranchIO/String.h
+++ b/BranchSDK/src/BranchIO/String.h
@@ -3,10 +3,12 @@
 #ifndef BRANCHIO_STRING_H__
 #define BRANCHIO_STRING_H__
 
+#ifdef WIN32
+#include <Windows.h>
+#endif  // WIN32
 #include <string>
 #ifdef WIN32
 #include <vector>
-#include <wstring>  // NOLINT
 #endif  // WIN32
 
 namespace BranchIO {

--- a/BranchSDK/src/BranchIO/String.h
+++ b/BranchSDK/src/BranchIO/String.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2020 Branch Metrics, Inc.
+
+#ifndef BRANCHIO_STRING_H__
+#define BRANCHIO_STRING_H__
+
+#include <string>
+#ifdef WIN32
+#include <vector>
+#include <wstring>  // NOLINT
+#endif  // WIN32
+
+namespace BranchIO {
+
+/**
+ * Adapter class to convert UTF-8 to UTF-16 and vice versa.
+ */
+class String {
+ public:
+    /**
+     * Default constructor and conversion operator from std::string
+     * @param s a UTF-8 string
+     */
+    String(const std::string& s = std::string()) : m_string(s) {}  // NOLINT
+
+    /**
+     * Conversion operator from const char*
+     * @param s a UTF-8 string
+     */
+    String(const char* s) : m_string(s) {}  // NOLINT
+
+    /**
+     * Obtain a UTF-8 representation of this String
+     * @return a UTF-8 string
+     */
+    std::string str() const { return m_string; }
+
+#ifdef WIN32
+    /**
+     * Conversion operator from std::wstring
+     * @param ws a UTF-16 string
+     */
+    String(const std::wstring& ws) : m_string(make_string(ws)) {}  // NOLINT
+
+    /**
+     * Conversion operator from const wchar_t*
+     * @param s a UTF-16 string
+     */
+    String(const wchar_t* ws) : m_string(make_string(ws)) {}  // NOLINT
+
+    /**
+     * Obtain a UTF-16 representation of this String
+     * @return a UTF-16 string
+     */
+    std::wstring wstr() const { return make_wstring(m_string); }
+
+ protected:
+    static std::string make_string(const std::wstring& wstr) {
+        if (wstr.length() <= 0) {
+            return std::string();
+        }
+
+        // Allow up to 4 chars per wide char for UTF-8 encoding, plus one for null termination
+        std::vector<char> buffer(wstr.length() * 4 + 1);
+        int length = WideCharToMultiByte(
+            CP_UTF8,
+            0,
+            wstr.c_str(),
+            static_cast<int>(wstr.length()),
+            &buffer[0],
+            static_cast<int>(buffer.size()) - 1,
+            NULL,
+            NULL);
+        if (length <= 0) {
+            return std::string();
+        }
+
+        return std::string(&buffer[0], &buffer[length]);
+    }
+
+    static std::wstring make_wstring(const std::string& str) {
+        if (str.length() <= 0) return std::wstring();
+
+        // Allow one wide char per char for UTF-8
+        std::vector<wchar_t> buffer(str.length() + 1);
+        int length = MultiByteToWideChar(
+            CP_UTF8,
+            0,
+            str.c_str(),
+            static_cast<int>(str.length()),
+            &buffer[0],
+            static_cast<int>(buffer.size()) - 1);
+        if (length <= 0) {
+            return std::wstring();
+        }
+
+        // look for null termination
+        return std::wstring(&buffer[0], &buffer[length]);
+    }
+#endif  // WIN32
+
+ private:
+    std::string m_string;
+};
+
+}  // namespace BranchIO
+
+#endif  // BRANCHIO_STRING_H__

--- a/BranchSDK/src/BranchIO/String.h
+++ b/BranchSDK/src/BranchIO/String.h
@@ -14,7 +14,14 @@
 namespace BranchIO {
 
 /**
- * Adapter class to convert UTF-8 to UTF-16 and vice versa.
+ * Adapter class to convert UTF-8 to UTF-16 and vice versa. Converts from
+ * any of the following types:
+ *   std::string
+ *   std::wstring
+ *   const char*
+ *   const wchar_t*
+ * Use the str() method to generate a UTF-8 std::string or wstr() to
+ * generate a UTF-16 std::wstring.
  */
 class String {
  public:

--- a/BranchSDK/src/BranchIO/fwd.h
+++ b/BranchSDK/src/BranchIO/fwd.h
@@ -20,6 +20,7 @@ class IRequestCallback;
 class JSONObject;
 class Request;
 class SessionInfo;
+class String;
 
 }  // namespace BranchIO
 

--- a/BranchSDK/test/StringTest.cpp
+++ b/BranchSDK/test/StringTest.cpp
@@ -1,0 +1,53 @@
+#include <BranchIO/String.h>
+
+#include <gtest/gtest.h>
+
+using namespace std;
+using namespace BranchIO;
+
+TEST(StringTest, DefaultInitialization) {
+    String s;
+    ASSERT_EQ(s.str(), "");
+}
+
+TEST(StringTest, StringInitialization) {
+    string expected("abc");
+    String s(expected);
+    ASSERT_EQ(s.str(), expected);
+}
+
+TEST(StringTest, PointerInitialization) {
+    const char* expected("abc");
+    String s(expected);
+    ASSERT_EQ(s.str(), expected);
+}
+
+#ifdef WIN32
+
+TEST(StringTest, WideStringInitialization) {
+    wstring expected(L"abc");
+    String s(expected);
+    ASSERT_EQ(s.wstr(), expected);
+}
+
+TEST(StringTest, WidePointerInitialization) {
+    const wchar_t* expected(L"abc");
+    String s(expected);
+    ASSERT_EQ(s.wstr(), expected);
+}
+
+TEST(StringTest, ConvertUTF16ToUTF8) {
+    wstring original(L"abc");
+    String s(original);
+
+    ASSERT_EQ(s.str(), "abc");
+}
+
+TEST(StringTest, ConvertUTF8ToUTF16) {
+    string original("abc");
+    String s(original);
+
+    ASSERT_EQ(s.wstr(), L"abc");
+}
+
+#endif  // WIN32


### PR DESCRIPTION
## Reference
SDK-1028: Wide string support for Windows

## Description
It's annoying to constantly convert wide strings to UTF-8 for the privilege of using this SDK. This change introduces an adapter class `BranchIO::String`, which can be initialized from any of the following types:

- std::string
- std::wstring
- const char*
- const wchar_t*

These constructors are not `explicit` (hence `// NOLINT` for each one). These are intended as conversion operators. The inbound side of the SDK is being converted to use `const BranchIO::String&` anywhere it accepted `const std::string&`. This is a wholesale API change, but no calling code has to be updated, so it's entirely transparent and not a breaking change. This is made possible by the conversion operators described above. But now on Windows, you can pass `std::wstring` or `const wchar_t*`, including `L` string literals, e.g. these four calls will all now compile and are entirely equivalent:

```c++
Branch::create("key_live_xyz", ...);
Branch::create(L"key_live_xyz", ...);
Branch::create(std::string("key_live_xyz"), ...);
Branch::create(std::wstring(L"key_live_xyz"), ...);
```

Strings are stored as UTF-8 std::strings. This keeps things portable, and UTF-8 will almost always be smaller. Plus, the SDK still uses UTF-8 everywhere else under the hood.

The `String::str()` or `String::wstr()` method may be used to retrieve either a UTF-8 or UTF-16 representation, respectively.

TODO: 
- ~~Finish this off for Event classes. (this PR)~~
- ~~Add getter methods to JSONObject and other classes to retrieve `BranchIO::String` instead of `std::string` (separate PR to come)~~ See #49
- ~~Convert ColorPicker to use this version of the SDK (currently takes the prod release, not the one from the repo)~~ See #49

None of these changes will be breaking changes.

## Testing Instructions
See `StringTest` unit test case.

## Risk Assessment [`LOW`]

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/cppguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
