### PR TITLE
Preprocessor macros do not honor namespacing.

### DIFF
--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -18,9 +18,9 @@
 // Create a string that looks like this:  "Branch Windows SDK v1.2.3"
 #define STRINGIZE2(s) #s
 #define STRINGIZE(s) STRINGIZE2(s)
-#define VER_FILE_VERSION_STR        STRINGIZE(VERSION_MAJOR)        \
-                                    "." STRINGIZE(VERSION_MINOR)    \
-                                    "." STRINGIZE(VERSION_REVISION)
+#define VER_FILE_VERSION_STR        STRINGIZE(BRANCHIO_VERSION_MAJOR)        \
+                                    "." STRINGIZE(BRANCHIO_VERSION_MINOR)    \
+                                    "." STRINGIZE(BRANCHIO_VERSION_REVISION)
 
 #define VER_FILE_VERSION_DISPLAY    "Branch "                       \
                                     VERSION_PLATFORM  " SDK v"      \

--- a/BranchSDK/src/BranchIO/Version.h
+++ b/BranchSDK/src/BranchIO/Version.h
@@ -3,12 +3,8 @@
 #ifndef BRANCHIO_VERSION_H__
 #define BRANCHIO_VERSION_H__
 
-namespace BranchIO {
-
-#define VERSION_MAJOR               1
-#define VERSION_MINOR               1
-#define VERSION_REVISION            0
-
-}  // namespace BranchIO
+#define BRANCHIO_VERSION_MAJOR               1
+#define BRANCHIO_VERSION_MINOR               1
+#define BRANCHIO_VERSION_REVISION            0
 
 #endif  // BRANCHIO_VERSION_H__


### PR DESCRIPTION
We have very generic macro names that can potentially cause conflicts in a public header.