### PR TITLE
Release 1.1.1

### DIFF
--- a/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
+++ b/BranchSDK-Samples/Windows/BranchDemo/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-BranchIO/1.1.0@branch/stable
+BranchIO/1.1.1@branch/stable
 
 [options]
 Poco:enable_mongodb=False

--- a/BranchSDK-Samples/Windows/ColorPicker/conanfile.txt
+++ b/BranchSDK-Samples/Windows/ColorPicker/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-BranchIO/1.1.0@branch/testing
+BranchIO/1.1.1@branch/stable
 
 [options]
 Poco:enable_mongodb=False

--- a/BranchSDK-Samples/Windows/TestBed/conanfile.txt
+++ b/BranchSDK-Samples/Windows/TestBed/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-BranchIO/1.1.0@branch/stable
+BranchIO/1.1.1@branch/stable
 
 [options]
 Poco:enable_mongodb=False

--- a/BranchSDK/src/BranchIO/Version.h
+++ b/BranchSDK/src/BranchIO/Version.h
@@ -5,6 +5,6 @@
 
 #define BRANCHIO_VERSION_MAJOR               1
 #define BRANCHIO_VERSION_MINOR               1
-#define BRANCHIO_VERSION_REVISION            0
+#define BRANCHIO_VERSION_REVISION            1
 
 #endif  // BRANCHIO_VERSION_H__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 # TODO(jdee): Set the version in one place and pass it around.
-project(root VERSION 1.1.0 LANGUAGES CXX)
+project(root VERSION 1.1.1 LANGUAGES CXX)
 
 # Determines handling of RPATH and related variables when building dylibs on Mac.
 # TODO(jdee): Review this. RPATH is an issue on Unix right now.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,11 @@
+2020-08-12  Version 1.1.1
+  * Added support for wide strings via BranchIO::String adapter class.
+
+  All public API methods that accept a string now take a BranchIO::String,
+  which can be constructed automatically from std::string, std::wstring,
+  const char\* or const wchar_t\*. Two new getters, Branch::getBranchKeyW()
+  and Branch::getVersionW(), were also introduced.
+
 2020-05-13  Version 1.1.0
   * Improvements to thread safety of LinkInfo and its ancestors.
   * Eliminate queueing and retry of /v1/url requests. A long link will now be

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class BranchioConan(ConanFile):
     # ----- Package metadata -----
     name = "BranchIO"
     # TODO(jdee): Set the version in one place and propagate it
-    version = "1.1.0"
+    version = "1.1.1"
     license = "MIT"
     description = "Branch Metrics deep linking and attribution analytics C++ SDK"
     topics = (


### PR DESCRIPTION
Bumped to version 1.1.1.
Updated examples to use `BranchIO/1.1.1@branch/stable`.

This has been tagged and released to Conan as `BranchIO/1.1.1@branch/stable`.