### PR TITLE
[SDK-1059] Disable tracking in testbed

### DIFF
--- a/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
@@ -390,3 +390,26 @@ BranchOperations::closeSession()
 
     branch->closeSession(new CloseCallback);
 }
+
+std::wstring
+BranchOperations::getTrackingButtonLabel()
+{
+    const auto isDisabled = branch->getAdvertiserInfo().isTrackingDisabled();
+    return isDisabled ? L"Enable Tracking" : L"Disable Tracking";
+}
+
+void
+BranchOperations::toggleTracking()
+{
+    const auto isDisabled = branch->getAdvertiserInfo().isTrackingDisabled();
+    if (isDisabled)
+    {
+        branch->getAdvertiserInfo().enableTracking();
+        outputTextField->appendText(L"Tracking enabled");
+    }
+    else
+    {
+        branch->getAdvertiserInfo().disableTracking();
+        outputTextField->appendText(L"Tracking disabled");
+    }
+}

--- a/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
@@ -159,6 +159,14 @@ void
 BranchOperations::showInitializationMessage()
 {
     outputTextField->appendText(wstring(L"Initialized Branch SDK v") + branch->getVersionW() + L" with key " + BRANCH_KEY);
+    if (branch->getAdvertiserInfo().isTrackingDisabled())
+    {
+        outputTextField->appendText(L"Tracking disabled");
+    }
+    else
+    {
+        outputTextField->appendText(L"Tracking enabled");
+    }
 }
 
 void

--- a/BranchSDK-Samples/Windows/TestBed/BranchOperations.h
+++ b/BranchSDK-Samples/Windows/TestBed/BranchOperations.h
@@ -28,6 +28,8 @@ struct BranchOperations
 	static void shutDownBranch();
 	static void showInitializationMessage();
 	static BranchIO::JSONObject getOpenResponse();
+	static std::wstring getTrackingButtonLabel();
+	static void toggleTracking();
 
 	static BranchIO::Branch* branch;
 	static TextField* outputTextField;

--- a/BranchSDK-Samples/Windows/TestBed/Button.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/Button.cpp
@@ -33,3 +33,9 @@ Button::Button(LPCWSTR text, int x, int y, int width, int height, int menu, HWND
 {
 
 }
+
+void
+Button::setText(const std::wstring& text)
+{
+	SendMessage(*this, WM_SETTEXT, 0, (LPARAM)text.c_str());
+}

--- a/BranchSDK-Samples/Windows/TestBed/Button.h
+++ b/BranchSDK-Samples/Windows/TestBed/Button.h
@@ -24,6 +24,8 @@ public:
         m_buttonPressCallback();
     }
 
+    void setText(const std::wstring& text);
+
 private:
     std::function<void()> m_buttonPressCallback;
 };

--- a/BranchSDK-Samples/Windows/TestBed/TestBed.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/TestBed.cpp
@@ -32,6 +32,7 @@ static int const ID_STANDARD_EVENT_BUTTON = 1004;
 static int const ID_CUSTOM_EVENT_BUTTON = 1005;
 static int const ID_GET_SHORT_URL_BUTTON = 1006;
 static int const ID_CLOSE_BUTTON = 1007;
+static int const ID_TRACKING_BUTTON = 1008;
 
 TextField outputTextField(L"Initializing...", 440, 20, 400, 400, ID_TEXT_FIELD);
 Button openButton(L"Open", 20, 20, 190, 50, ID_OPEN_BUTTON);
@@ -41,6 +42,7 @@ Button logoutButton(L"Logout", 20, 230, 190, 50, ID_LOGOUT_BUTTON);
 Button standardEventButton(L"Standard Event", 230, 20, 190, 50, ID_STANDARD_EVENT_BUTTON);
 Button customEventButton(L"Custom Event", 230, 90, 190, 50, ID_CUSTOM_EVENT_BUTTON);
 Button getShortURLButton(L"Get Short URL", 230, 160, 190, 50, ID_GET_SHORT_URL_BUTTON);
+Button trackingButton(L"Disable Tracking", 230, 230, 190, 50, ID_TRACKING_BUTTON);
 
 // Forward declarations of functions included in this code module:
 ATOM                MyRegisterClass(HINSTANCE hInstance);
@@ -160,6 +162,9 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
    customEventButton.create(hWnd);
    getShortURLButton.create(hWnd);
    closeButton.create(hWnd);
+   trackingButton.create(hWnd);
+
+   trackingButton.setText(BranchOperations::getTrackingButtonLabel());
 
    openButton.setButtonPressCallback([]() {
        BranchOperations::openURL(L"https://win32.app.link/crtafBueu9");
@@ -172,6 +177,10 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
    customEventButton.setButtonPressCallback(BranchOperations::logCustomEvent);
    getShortURLButton.setButtonPressCallback(BranchOperations::getShortURL);
    closeButton.setButtonPressCallback(BranchOperations::closeSession);
+   trackingButton.setButtonPressCallback([]() {
+       BranchOperations::toggleTracking();
+       trackingButton.setText(BranchOperations::getTrackingButtonLabel());
+   });
 
    BranchOperations::showInitializationMessage();
 
@@ -228,6 +237,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                 break;
             case ID_CLOSE_BUTTON:
                 closeButton.onPress();
+                break;
+            case ID_TRACKING_BUTTON:
+                trackingButton.onPress();
                 break;
             default:
                 return DefWindowProc(hWnd, message, wParam, lParam);


### PR DESCRIPTION
Added a button labeled "Disable Tracking" or "Enable Tracking," depending on the current state, to exercise this functionality.