### PR TITLE
[SDK-1071] fix os version

### DIFF
--- a/BranchSDK/src/BranchIO/DeviceInfo.cpp
+++ b/BranchSDK/src/BranchIO/DeviceInfo.cpp
@@ -12,6 +12,7 @@
 
 using Poco::Net::NetworkInterface;
 using Poco::Net::IPAddress;
+using namespace std;
 
 namespace BranchIO {
 
@@ -55,7 +56,16 @@ DeviceInfo::setOs(const std::string &os) {
 
 DeviceInfo&
 DeviceInfo::setOsVersion(const std::string &osVersion) {
-    return doAddProperty(Defines::JSONKEY_DEVICE_OS_VERSION, osVersion);
+    /*
+     * Remove any trailing non-numeric component to generate x.y[.z]
+     */
+    string::size_type firstNonNumeric(osVersion.find_first_not_of("0123456789."));
+    string actualOsVersion(osVersion);
+    if (firstNonNumeric != string::npos) {
+        actualOsVersion = osVersion.substr(0, firstNonNumeric);
+    }
+
+    return doAddProperty(Defines::JSONKEY_DEVICE_OS_VERSION, actualOsVersion);
 }
 
 DeviceInfo&

--- a/BranchSDK/test/BranchDeviceInfoTest.cpp
+++ b/BranchSDK/test/BranchDeviceInfoTest.cpp
@@ -23,7 +23,9 @@ TEST(BranchDeviceInfoTest, TestSetters)
         .setMACAddress("My MACAddress")
         .setModel("My model")
         .setOs("My os")
-        .setOsVersion("My osVersion")
+	// Note os_version is stripped out because it is converted to a blank string.
+	// This is why this test case passes.
+        .setOsVersion("My osVersion")  
         .setSDK("My sdk")
         .setSDKVersion("My sdkVersion")
         .setUserAgent("My userAgent");
@@ -38,4 +40,15 @@ TEST(BranchDeviceInfoTest, TestSetters)
 
         ASSERT_STREQ("My", value.substr(0, 2).c_str());
     }
+}
+
+TEST(BranchDeviceInfoTest, TestOsVersion)
+{
+    DeviceInfo info;
+
+    info.setOsVersion("6.2 (Build 9200)");
+
+    string osVersion = info.getStringProperty("os_version");
+
+    ASSERT_EQ(osVersion, "6.2");
 }


### PR DESCRIPTION
We should only send semver-style OS versions to the API Open service. The service will also be updated to handle this case, but this should be fixed in the SDK.