### PR TITLE
Limit size of text output in TestBed

### DIFF
--- a/BranchSDK-Samples/Windows/TestBed/TextField.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/TextField.cpp
@@ -1,5 +1,6 @@
 #include "TextField.h"
 
+#include <cassert>
 #include <vector>
 
 #include "Windowsx.h"
@@ -65,9 +66,18 @@ TextField::getText() const
 }
 
 void
-TextField::appendText(const std::wstring& text)
+TextField::appendText(const std::wstring& text, size_t maxLength)
 {
 	// Prevent multiple threads from clobbering the text area at the same time.
 	ScopeLock l(m_lock);
-	setText(getText() + L"\r\n" + text);
+	wstring newText = getText() + L"\r\n" + text;
+	// Limit text length
+	const wstring::size_type total = newText.length();
+	const int offset = total - maxLength;
+	if (offset > 0)
+	{
+		newText = newText.substr(offset, maxLength - 1);
+	}
+	assert(newText.length() <= maxLength);
+	setText(newText);
 }

--- a/BranchSDK-Samples/Windows/TestBed/TextField.h
+++ b/BranchSDK-Samples/Windows/TestBed/TextField.h
@@ -11,5 +11,6 @@ public:
     void setText(const std::wstring& text);
     std::wstring getText() const;
 
-    void appendText(const std::wstring& text);
+    // maxLength limits the character count in the Edit control to avoid growing without bound.
+    void appendText(const std::wstring& text, size_t maxLength = 100000);
 };


### PR DESCRIPTION
In a long-term automated test suite, the size of the output Edit control can grow without bound. This change limits the size to avoid running out of memory.