### PR TITLE
Simplify TestBed open logic

### DIFF
--- a/BranchSDK-Samples/Windows/ColorPicker/ColorPicker.cpp
+++ b/BranchSDK-Samples/Windows/ColorPicker/ColorPicker.cpp
@@ -359,7 +359,6 @@ void initializeBranch()
     _appInfo
         .setAppVersion("1.0")
         .setCountryCode("US")
-        .setDeveloperIdentity("Branch Metrics")
         .setEnvironment("FULL_APP")
         .setLanguage("en");
 

--- a/BranchSDK-Samples/Windows/TestBed/TestBed.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/TestBed.cpp
@@ -65,19 +65,16 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     LoadStringW(hInstance, IDC_TESTBED, szWindowClass, MAX_LOADSTRING);
     LoadStringW(hInstance, IDS_APP_TITLE, szTitle, MAX_LOADSTRING);
 
-    // Initialize Branch
-    BranchOperations::initBranch(lpCmdLine ? lpCmdLine : L"", &outputTextField);
-
-    // While the Branch open request is in flight, try to obtain the named mutex.
+    // Forward this link to the running instance if there is one.
     if (Util::isInstanceRunning())
     {
-        // Wait for response from Branch, send to running instance, then exit
-        BranchOperations::waitForOpen(INFINITE);
-        String sResponse(BranchOperations::getOpenResponse().stringify());
-        Util::sendToRunningInstance(szWindowClass, sResponse.wstr());
+        Util::sendToRunningInstance(szWindowClass, lpCmdLine);
         // Now exit
         return 0;
     }
+
+    // Initialize Branch
+    BranchOperations::initBranch(lpCmdLine ? lpCmdLine : L"", &outputTextField);
 
     MyRegisterClass(hInstance);
 
@@ -289,8 +286,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                 const wchar_t* buffer((const wchar_t*)cds->lpData);
                 size_t length((size_t)cds->cbData / sizeof(wchar_t) - 1);
 
-                wstring payload(buffer, buffer + length);
-                outputTextField.appendText(wstring(L"Forwarded open response: ") + payload);
+                wstring url(buffer, buffer + length);
+                BranchOperations::openURL(url);
             }
         }
         break;


### PR DESCRIPTION
TestBed was attempting something too fancy for the SDK. It would first initialize Branch, posting an open request immediately on launch. Then it would check for a running instance of the app. If it detected an instance of the app already running, it would wait for the open response then forward the response to the running instance. This was done in part to help win any race with the Web SDK, though that has also been addressed by `$desktop_web_open_delay_ms`. Unfortunately, this doesn't work correctly at the moment. The running process has to execute any call to `Branch::openSession`, or its in-memory Session ID won't be updated when the new open is executed. It will just report the open results and continue using the previous Session ID.

This change just passes the URI off to the running instance instead. Everything continues to work as before. It would be nice to support this in a future release of the SDK, but this is a better example of usage today.