### PR TITLE
[SDK-1086] Add Request ID to logs

### DIFF
--- a/BranchSDK/src/BranchIO/Util/APIClientSession.cpp
+++ b/BranchSDK/src/BranchIO/Util/APIClientSession.cpp
@@ -133,7 +133,19 @@ APIClientSession::processResponse(IRequestCallback& callback, JSONObject& result
     if (isShuttingDown()) return false;
 
     HTTPResponse::HTTPStatus status = response.getStatus();
-    BRANCH_LOG_D(status << " " << response.getReason());
+
+    string requestId;
+    try {
+        requestId = response["X-Branch-Request-Id"];
+    }
+    catch (NotFoundException&) {
+    }
+    if (!requestId.empty()) {
+        BRANCH_LOG_D("[" << requestId << "] " << status << " " << response.getReason());
+    }
+    else {
+        BRANCH_LOG_D(status << " " << response.getReason());
+    }
 
     // @todo(jdee): Fine-tune this success-failure determination
     if (status == HTTPResponse::HTTP_OK) {


### PR DESCRIPTION
This adds the value of any `X-Branch-Request-Id` header in an API response to the logs on Debug level, with the status.

```
2020-11-16-15:48:31.629144|Debug|9504|APIClientSession.cpp:144[processResponse]|[cb1f220e9a5148cd8e4f2bb082b7b953-2020111615] 200 OK
2020-11-16-15:48:31.631140|Verbose|9504|APIClientSession.cpp:155[processResponse]|Response body: {"data":"{\"+clicked_branch_link\":false,\"+is_first_session\":true}","device_fingerprint_id":"856910924455859796","identity_id":"856910924484511566","link":"https:\/\/win32.app.link?%24identity_id=856910924484511566","session_id":"856910924471346045"}
```
