### PR TITLE
[SDK-1095] Also send WAID in v1 events if present

### DIFF
--- a/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
@@ -111,6 +111,12 @@ BranchOperations::initBranch(const std::wstring& initialUrl, TextField* textFiel
 
     branch = Branch::create(BRANCH_KEY, &appInfo);
 
+    /*
+     * The Windows Advertising Identifier requires a UWP dependency and is not ordinarily available
+     * for Win32. If you have it available, you can pass it here.
+     */
+    branch->getAdvertiserInfo().addId(AdvertiserInfo::WINDOWS_ADVERTISING_ID, "my-waid");
+
     wstring::size_type prefixLength = min(wstring(BRANCH_URI_SCHEME).length(), initialUrl.length());
     wstring prefix = initialUrl.substr(0, prefixLength);
     if (!initialUrl.empty() && prefix == BRANCH_URI_SCHEME)

--- a/BranchSDK/src/BranchIO/Defines.cpp
+++ b/BranchSDK/src/BranchIO/Defines.cpp
@@ -50,6 +50,7 @@ const char *Defines::JSONKEY_SESSION_FINGERPRINT = "device_fingerprint_id";
 const char *Defines::JSONKEY_SESSION_ID = "session_id";
 const char *Defines::JSONKEY_SESSION_IDENTITY = "identity_id";
 const char *Defines::JSONKEY_TRACKING_DISABLED = "tracking_disabled";
+const char* Defines::JSONKEY_WINDOWS_ADVERTISING_ID = "windows_advertising_id";
 
 // Branch Url Path
 const char *Defines::BASE_PATH_V2 = "https://api2.branch.io/";

--- a/BranchSDK/src/BranchIO/Defines.h
+++ b/BranchSDK/src/BranchIO/Defines.h
@@ -56,6 +56,7 @@ class BRANCHIO_DLL_EXPORT Defines {
     static const char *JSONKEY_SESSION_ID;               ///< Session Id
     static const char *JSONKEY_SESSION_IDENTITY;         ///< Session Identity
     static const char *JSONKEY_TRACKING_DISABLED;        ///< Tracking Disabled
+    static const char* JSONKEY_WINDOWS_ADVERTISING_ID;   ///< Windows Advertising ID
 
     // Branch Url Path
     static const char *BASE_PATH_V1;                     ///< V1 Base Path

--- a/BranchSDK/src/BranchIO/Event/BaseEvent.cpp
+++ b/BranchSDK/src/BranchIO/Event/BaseEvent.cpp
@@ -96,7 +96,7 @@ BaseEvent::packageV1Event(IPackagingInfo &packagingInfo, JSONObject &jsonObject)
 
     string waid = packagingInfo.getAdvertiserInfo().getStringProperty(Defines::JSONKEY_WINDOWS_ADVERTISING_ID);
     if (!waid.empty()) {
-        jsonObject.set(Defines::JSONKEY_WINDOWS_ADVERTISING_ID, waid);
+        jsonObject.set(JSONKEY_ADVERTISING_IDS, packagingInfo.getAdvertiserInfo().toJSON());
     }
 
     if (getAPIEndpoint() == Defines::APIEndpoint::REGISTER_OPEN && jsonObject.has(Defines::JSONKEY_SESSION_ID)) {

--- a/BranchSDK/src/BranchIO/Event/BaseEvent.cpp
+++ b/BranchSDK/src/BranchIO/Event/BaseEvent.cpp
@@ -10,6 +10,7 @@
 #include "BranchIO/AdvertiserInfo.h"
 
 using Poco::Mutex;
+using namespace std;
 
 namespace BranchIO {
 
@@ -92,6 +93,11 @@ BaseEvent::packageV1Event(IPackagingInfo &packagingInfo, JSONObject &jsonObject)
     jsonObject += packagingInfo.getSessionInfo().toJSON();
     jsonObject += packagingInfo.getDeviceInfo().toJSON();
     jsonObject += packagingInfo.getAppInfo().toJSON();
+
+    string waid = packagingInfo.getAdvertiserInfo().getStringProperty(Defines::JSONKEY_WINDOWS_ADVERTISING_ID);
+    if (!waid.empty()) {
+        jsonObject.set(Defines::JSONKEY_WINDOWS_ADVERTISING_ID, waid);
+    }
 
     if (getAPIEndpoint() == Defines::APIEndpoint::REGISTER_OPEN && jsonObject.has(Defines::JSONKEY_SESSION_ID)) {
         jsonObject.remove(Defines::JSONKEY_SESSION_ID);

--- a/BranchSDK/src/BranchIO/Util/RequestManager.cpp
+++ b/BranchSDK/src/BranchIO/Util/RequestManager.cpp
@@ -160,6 +160,7 @@ RequestManager::RequestTask::runTask() {
         payload.remove(Defines::JSONKEY_DEVICE_MAC_ADDRESS);       // mac_address
         payload.remove(Defines::JSONKEY_SESSION_FINGERPRINT);      // device_fingerprint_id
         payload.remove(Defines::JSONKEY_SESSION_IDENTITY);         // identity_id
+        payload.remove(Defines::JSONKEY_WINDOWS_ADVERTISING_ID);
     }
 
     // Send request synchronously

--- a/BranchSDK/src/BranchIO/Util/RequestManager.cpp
+++ b/BranchSDK/src/BranchIO/Util/RequestManager.cpp
@@ -160,7 +160,7 @@ RequestManager::RequestTask::runTask() {
         payload.remove(Defines::JSONKEY_DEVICE_MAC_ADDRESS);       // mac_address
         payload.remove(Defines::JSONKEY_SESSION_FINGERPRINT);      // device_fingerprint_id
         payload.remove(Defines::JSONKEY_SESSION_IDENTITY);         // identity_id
-        payload.remove(Defines::JSONKEY_WINDOWS_ADVERTISING_ID);
+        payload.remove("advertising_ids");
     }
 
     // Send request synchronously


### PR DESCRIPTION
The Windows Advertising ID requires UWP and is difficult to get to in Win32. But in case an app has it available, the SDK does provide support for it. This change includes it in v1 events if tracking is enabled.

```cpp
branch->getAdvertiserInfo().addId(AdvertiserInfo::WINDOWS_ADVERTISING_ID, "my-waid");
```

```
2020-12-23-16:56:00.466067|Debug|11724|APIClientSession.cpp:117[sendRequest]|Sending request to /v1/open
2020-12-23-16:56:00.466067|Verbose|11724|APIClientSession.cpp:118[sendRequest]|Event Payload: {"app_version":"1.0","branch_key":"key_live_oiT8IkxqCmpGcDT35ttO1fkdExktZD1x","lat_val":0,"os":"Windows 10","os_version":"10.0","sdk":"native","sdk_version":"1.1.2","tracking_disabled":true}
2020-12-23-16:56:00.809279|Debug|11724|APIClientSession.cpp:103[post]|Request sent. Waiting for response.
2020-12-23-16:56:01.012938|Debug|11724|APIClientSession.cpp:144[processResponse]|[90da1fbbe6b94768a64048f33508fef6-2020122316] 200 OK
2020-12-23-16:56:01.012938|Verbose|11724|APIClientSession.cpp:155[processResponse]|Response body: {"data":"{\"+clicked_branch_link\":false,\"+is_first_session\":true}","device_fingerprint_id":"870336259573813454","identity_id":"870336259579164624","link":"https:\/\/win32.app.link?%24identity_id=870336259579164624","session_id":"870336259574227875"}
2020-12-23-16:56:01.012938|Debug|11724|Branch.cpp:97[onSuccess]|Branch::SessionCallback() Success       JSON: {"data":{"+clicked_branch_link":false,"+is_first_session":true},"device_fingerprint_id":"870336259573813454","identity_id":"870336259579164624","link":"https:\/\/win32.app.link?%24identity_id=870336259579164624","session_id":"870336259574227875"}
2020-12-23-16:56:01.012938|Verbose|11724|Request.cpp:68[send]|POST Success
2020-12-23-16:56:04.246468|Debug|11724|APIClientSession.cpp:117[sendRequest]|Sending request to /v1/open
2020-12-23-16:56:04.246468|Verbose|11724|APIClientSession.cpp:118[sendRequest]|Event Payload: {"advertising_ids":{"windows_advertising_id":"my-waid"},"app_version":"1.0","branch_key":"key_live_oiT8IkxqCmpGcDT35ttO1fkdExktZD1x","lat_val":0,"local_ip":"fdb2:2c26:f4e4:0:2c55:d32f:60f2:4ead","mac_address":"00:1c:42:7e:a2:03","os":"Windows 10","os_version":"10.0","sdk":"native","sdk_version":"1.1.2"}
2020-12-23-16:56:04.513156|Debug|11724|APIClientSession.cpp:103[post]|Request sent. Waiting for response.
2020-12-23-16:56:04.793800|Debug|11724|APIClientSession.cpp:144[processResponse]|[dbc0c102efc4486289f11901b3eb281c-2020122316] 200 OK
2020-12-23-16:56:04.793800|Verbose|11724|APIClientSession.cpp:155[processResponse]|Response body: {"data":"{\"+clicked_branch_link\":false,\"+is_first_session\":true}","device_fingerprint_id":"870020622661585394","identity_id":"870336275311139080","link":"https:\/\/win32.app.link?%24identity_id=870336275311139080","session_id":"870336275311222920"}
2020-12-23-16:56:04.793800|Debug|11724|Branch.cpp:97[onSuccess]|Branch::SessionCallback() Success       JSON: {"data":{"+clicked_branch_link":false,"+is_first_session":true},"device_fingerprint_id":"870020622661585394","identity_id":"870336275311139080","link":"https:\/\/win32.app.link?%24identity_id=870336275311139080","session_id":"870336275311222920"}
2020-12-23-16:56:04.793800|Verbose|11724|Request.cpp:68[send]|POST Success
2020-12-23-16:56:05.590217|Debug|11724|RequestManager.cpp:134[run]|Terminating RequestManager thread.
```


```