### PR TITLE
[SDK-1117] Fix signed/unsigned comparison issue in TestBed

### DIFF
--- a/BranchSDK-Samples/Windows/TestBed-Basic/TestBed-Basic-Package/Product.wxs
+++ b/BranchSDK-Samples/Windows/TestBed-Basic/TestBed-Basic-Package/Product.wxs
@@ -32,7 +32,7 @@
 	<Fragment>
 		<ComponentGroup Id="ProductComponents" Directory="INSTALLBINFOLDER" >
 			<Component Id="TestBedBinary" Guid="b5efe49a-f3f1-4623-b82e-9b2500d8f340">
-        <File Id="TestBedBinaryFile" Source="$(var.ProjectDir)..\Release\TestBed-Basic.exe" />
+        <File Id="TestBedBinaryFile" Source="$(var.ProjectDir)..\Debug\TestBed-Basic.exe" />
 
         <!-- Add Registry entries for URI redirection -->
         <!-- testbedbasic is the URI scheme from the Branch Dashboard -->

--- a/BranchSDK-Samples/Windows/TestBed/TextField.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/TextField.cpp
@@ -75,7 +75,7 @@ TextField::appendText(const std::wstring& text, size_t maxLength)
 	const size_t total = min(maxLength, newText.length());
 	if (total > maxLength)
 	{
-		const SSIZE_T offset = total - maxLength;
+		const size_t offset = total - maxLength;
 		newText = newText.substr(offset, maxLength - 1);
 	}
 	assert(newText.length() <= maxLength);

--- a/BranchSDK-Samples/Windows/TestBed/TextField.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/TextField.cpp
@@ -72,7 +72,7 @@ TextField::appendText(const std::wstring& text, size_t maxLength)
 	ScopeLock l(m_lock);
 	wstring newText = getText() + L"\r\n" + text;
 	// Limit text length
-	const size_t total = min(maxLength, newText.length());
+	const wstring::size_type total = newText.length();
 	if (total > maxLength)
 	{
 		const size_t offset = total - maxLength;

--- a/BranchSDK-Samples/Windows/TestBed/TextField.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/TextField.cpp
@@ -72,10 +72,10 @@ TextField::appendText(const std::wstring& text, size_t maxLength)
 	ScopeLock l(m_lock);
 	wstring newText = getText() + L"\r\n" + text;
 	// Limit text length
-	const wstring::size_type total = newText.length();
-	const __int64 offset = total - maxLength;
-	if (offset > 0)
+	const size_t total = min(maxLength, newText.length());
+	if (total > maxLength)
 	{
+		const SSIZE_T offset = total - maxLength;
 		newText = newText.substr(offset, maxLength - 1);
 	}
 	assert(newText.length() <= maxLength);


### PR DESCRIPTION
TestBed can crash on occasion because of a signed/unsigned integer comparison when limiting the size of the output text to the text field. This has mainly been observed in TestBed-Basic, but the source code is the same for all flavors.

I'd also like to quickly roll this into master for a better demo/evaluation experience, meaning another PR momentarily.

Also changing the TestBed-Basic MSI to install the Debug build for better logs.