### PR TITLE
[CORE-1740] Improve TLS configuration and handling

### DIFF
--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -171,7 +171,7 @@ Branch *Branch::create(const String& branchKey, AppInfo* pInfo) {
 #endif
 
     // Set these on the current app
-    if (hasGlobalTrackingDisabled && !storage.has("advertiser.trackingDisbled")) {
+    if (hasGlobalTrackingDisabled && !storage.has("advertiser.trackingDisabled")) {
         storage.setBoolean("advertiser.trackingDisabled", isGlobalTrackingDisabled);
     }
     if (!globalDeviceFingerprintId.empty() && !storage.has("session.device_fingerprint_id")) {

--- a/BranchSDK/src/BranchIO/Util/APIClientSession.cpp
+++ b/BranchSDK/src/BranchIO/Util/APIClientSession.cpp
@@ -95,7 +95,10 @@ APIClientSession::post(
     }
     catch (const Poco::Exception& e) {
         if (isShuttingDown()) return false;
-        callback.onStatus(0, 0, string(e.what()) + ": " + e.message());
+        string description(e.what());
+        description += ": " + e.message();
+        BRANCH_LOG_W("Request failed. " << description);
+        callback.onStatus(0, 0, description);
     }
     return false;
 }

--- a/BranchSDK/src/BranchIO/Util/APIClientSession.cpp
+++ b/BranchSDK/src/BranchIO/Util/APIClientSession.cpp
@@ -9,6 +9,7 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/NetException.h>
+#include <Poco/Net/SSLManager.h>
 #include <Poco/NullStream.h>
 #include <Poco/StreamCopier.h>
 #include <Poco/URI.h>
@@ -25,19 +26,6 @@ using namespace Poco::Net;
 
 namespace BranchIO {
 
-Poco::Net::Context::Ptr APIClientSession::getContext() {
-    return new Context
-#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
-        // Unix / Mac
-        (Context::CLIENT_USE, "", "", "",
-         Context::VERIFY_NONE, 9, false,
-         "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
-#else
-        // Windows
-        (Context::CLIENT_USE, "");
-#endif
-}
-
 APIClientSession&
 APIClientSession::instance() {
     // constructed the first time through
@@ -48,7 +36,7 @@ APIClientSession::instance() {
 APIClientSession::APIClientSession(const std::string& urlBase) :
     HTTPSClientSession(URI(urlBase).getHost(),
     URI(urlBase).getPort(),
-    getContext()),
+    Poco::Net::SSLManager::instance().defaultClientContext()),
     _urlBase(urlBase),
     _shuttingDown(false) {
 }

--- a/BranchSDK/src/BranchIO/Util/APIClientSession.h
+++ b/BranchSDK/src/BranchIO/Util/APIClientSession.h
@@ -21,12 +21,6 @@ class APIClientSession
       public virtual IClientSession {
  public:
     /**
-     * @return SSL session context
-     * @todo(jdee): Document
-     */
-    static Poco::Net::Context::Ptr getContext();
-
-    /**
      * @return this instance
      * @todo(jdee): Document
      */

--- a/BranchSDK/src/BranchIO/Util/RequestManager.cpp
+++ b/BranchSDK/src/BranchIO/Util/RequestManager.cpp
@@ -209,7 +209,7 @@ RequestManager::RequestTask::runTask() {
     if (_manager.getClientSession()) {
         result = _request.send(_event.getAPIEndpoint(), payload, *_callback, _manager.getClientSession());
     } else {
-        APIClientSession& clientSession(APIClientSession::instance());
+        APIClientSession clientSession(BRANCH_IO_URL_BASE);
         _manager.setClientSession(&clientSession);
         result = _request.send(_event.getAPIEndpoint(), payload, *_callback, &clientSession);
         _manager.setClientSession(nullptr);

--- a/BranchSDK/src/BranchIO/Util/RequestManager.cpp
+++ b/BranchSDK/src/BranchIO/Util/RequestManager.cpp
@@ -59,7 +59,7 @@ RequestManager::RequestManager(IPackagingInfo& packagingInfo, IClientSession *cl
         "" /* no client cert required */,
         Context::VERIFY_NONE, /* no client cert required */
         Context::OPT_DEFAULTS, /* OPT_PERFORM_REVOCATION_CHECK | OPT_TRUST_ROOTS_WIN_CERT_STORE | OPT_USE_STRONG_CRYPTO */
-        Context::CERT_STORE_CA
+        Context::CERT_STORE_ROOT /* Cert:\LocalMachine\Root */
     ));
 }
 

--- a/BranchSDK/src/BranchIO/Util/RequestManager.cpp
+++ b/BranchSDK/src/BranchIO/Util/RequestManager.cpp
@@ -25,35 +25,6 @@ RequestManager::RequestManager(IPackagingInfo& packagingInfo, IClientSession *cl
     _clientSession(clientSession),
     _shuttingDown(false),
     _currentRequest(nullptr) {
-    // https://pocoproject.org/docs/Poco.Net.Context.html
-    /*
-     * From <Poco/Net/Context.h>:
-     * 	Context(Usage usage,
-		const std::string& certificateNameOrPath, 
-		VerificationMode verMode = VERIFY_RELAXED,
-		int options = OPT_DEFAULTS,
-		const std::string& certificateStoreName = CERT_STORE_MY);
-			/// Creates a Context.
-			/// 
-			///   * usage specifies whether the context is used by a client or server,
-			///     as well as which protocol to use.
-			///   * certificateNameOrPath specifies either the subject name of the certificate to use,
-			///     or the path of a PKCS #12 file containing the certificate and corresponding private key.
-			///     If a subject name is specified, the certificate must be located in the certificate 
-			///     store specified by certificateStoreName. If a path is given, the OPT_LOAD_CERT_FROM_FILE
-			///     option must be set.
-			///   * verificationMode specifies whether and how peer certificates are validated.
-			///   * options is a combination of Option flags.
-			///   * certificateStoreName specifies the name of the Windows certificate store
-			///     to use for loading the certificate. Predefined constants
-			///     CERT_STORE_MY, CERT_STORE_ROOT, etc. can be used.
-			///
-			/// Note: you can use OpenSSL to convert a certificate and private key in PEM format
-			/// into PKCS #12 format required to import into the Context:
-			///
-			///     openssl pkcs12 -export -inkey cert.key -in cert.crt -out cert.pfx 
-
-     */
     /*
      * Note that the following call will always generate an exception warning message in Visual Studio like:
      * Exception thrown at 0x00007FF87DB8D759 in TestBed-Local.exe: Microsoft C++ exception: Poco::Net::NoCertificateException at memory location 0x000000FD251FC1F0.
@@ -61,7 +32,7 @@ RequestManager::RequestManager(IPackagingInfo& packagingInfo, IClientSession *cl
      * https://github.com/pocoproject/poco/blob/poco-1.10.1/NetSSL_Win/src/SecureSocketImpl.cpp#L692.
      * This is not a fatal error. API clients do not supply a cert for authentication.
      */
-    Poco::Net::SSLManager::instance().initializeClient(0, 0, new Context(Context::TLS_CLIENT_USE, "" /* no client cert required */));
+    Poco::Net::SSLManager::instance().initializeClient(nullptr, nullptr, new Context(Context::TLS_CLIENT_USE, "" /* no client cert required */));
 }
 
 RequestManager::~RequestManager() {


### PR DESCRIPTION
The warning that appears in Visual Studio regarding a Poco::Net::NoCertificateException is entirely benign and expected. See code comments.

This change does not have much impact on behavior. Instead of configuring an ad hoc Context for each request, the SSLManager is used to initialize the default client context, which is then reused with each Context. It's not clear if a Poco HTTPSClientSession can be reused at all on Windows, but SSL Session Caching is always in effect, which minimizes the cost of reconnection.

Some additional logging was also added to better report real failures.