### PR TITLE
[SDK-1113] updates for testing

### DIFF
--- a/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
@@ -61,7 +61,7 @@ BranchOperations::openURL(const std::wstring& url)
         openResponse = JSONObject();
     }
 
-    outputTextField->appendText(wstring(L"Opening ") + url);
+    outputTextField->appendText(wstring(L"Opening '") + url + L"'");
 
     struct OpenCallback : IRequestCallback
     {
@@ -429,6 +429,10 @@ BranchOperations::toggleTracking()
     {
         branch->getAdvertiserInfo().enableTracking();
         outputTextField->appendText(L"Tracking enabled");
+        // It's necessary to send a new /v1/open after enabling tracking to obtain
+        // a fresh session_id, or subsequent calls fail. This can be rolled into the
+        // SDK. This is what the Web SDK does, e.g.
+        openURL(L"");
     }
     else
     {

--- a/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
@@ -61,24 +61,24 @@ BranchOperations::openURL(const std::wstring& url)
         openResponse = JSONObject();
     }
 
-    outputTextField->appendText(wstring(L"Opening '") + url + L"'");
+    outputTextField->setText(wstring(L"Opening '") + url + L"'");
 
     struct OpenCallback : IRequestCallback
     {
         void onSuccess(int id, JSONObject payload)
         {
-            outputTextField->appendText(wstring(L"Successful open response: ") + String(payload.stringify()).wstr());
+            outputTextField->setText(wstring(L"Successful open response: ") + String(payload.stringify()).wstr());
             done(payload);
         }
 
         void onStatus(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch open status: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch open status: ") + String(message).wstr());
         }
 
         void onError(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch open error: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch open error: ") + String(message).wstr());
             done(JSONObject());
         }
 
@@ -173,14 +173,14 @@ BranchOperations::shutDownBranch()
 void
 BranchOperations::showInitializationMessage()
 {
-    outputTextField->appendText(wstring(L"Initialized Branch SDK v") + branch->getVersionW() + L" with key " + s_branchKey);
+    outputTextField->setText(wstring(L"Initialized Branch SDK v") + branch->getVersionW() + L" with key " + s_branchKey);
     if (branch->getAdvertiserInfo().isTrackingDisabled())
     {
-        outputTextField->appendText(L"Tracking disabled");
+        outputTextField->setText(L"Tracking disabled");
     }
     else
     {
-        outputTextField->appendText(L"Tracking enabled");
+        outputTextField->setText(L"Tracking enabled");
     }
 }
 
@@ -191,18 +191,18 @@ BranchOperations::login(const std::wstring& username)
     {
         void onSuccess(int id, JSONObject payload)
         {
-            outputTextField->appendText(wstring(L"Successful login response: ") + String(payload.stringify()).wstr());
+            outputTextField->setText(wstring(L"Successful login response: ") + String(payload.stringify()).wstr());
             done();
         }
 
         void onStatus(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch login status: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch login status: ") + String(message).wstr());
         }
 
         void onError(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch login error: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch login error: ") + String(message).wstr());
             done();
         }
 
@@ -223,18 +223,18 @@ BranchOperations::logout()
     {
         void onSuccess(int id, JSONObject payload)
         {
-            outputTextField->appendText(wstring(L"Successful logout response: ") + String(payload.stringify()).wstr());
+            outputTextField->setText(wstring(L"Successful logout response: ") + String(payload.stringify()).wstr());
             done();
         }
 
         void onStatus(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch logout status: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch logout status: ") + String(message).wstr());
         }
 
         void onError(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch logout error: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch logout error: ") + String(message).wstr());
             done();
         }
 
@@ -263,24 +263,24 @@ BranchOperations::logStandardEvent()
         .setTransactionId("Transaction123");
 
     string eventJson(event.toJSON().stringify());
-    outputTextField->appendText(wstring(L"Sending standard event: ") + String(eventJson).wstr());
+    outputTextField->setText(wstring(L"Sending standard event: ") + String(eventJson).wstr());
 
     struct StandardEventCallback : IRequestCallback
     {
         void onSuccess(int id, JSONObject payload)
         {
-            outputTextField->appendText(wstring(L"Successful standard event response: ") + String(payload.stringify()).wstr());
+            outputTextField->setText(wstring(L"Successful standard event response: ") + String(payload.stringify()).wstr());
             done();
         }
 
         void onStatus(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch standard event status: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch standard event status: ") + String(message).wstr());
         }
 
         void onError(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch standard event error: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch standard event error: ") + String(message).wstr());
             done();
         }
 
@@ -302,24 +302,24 @@ BranchOperations::logCustomEvent()
     event.addCustomDataProperty(L"foo", L"Bar");
 
     string eventJson(event.toJSON().stringify());
-    outputTextField->appendText(wstring(L"Sending custom event: ") + String(eventJson).wstr());
+    outputTextField->setText(wstring(L"Sending custom event: ") + String(eventJson).wstr());
 
     struct CustomEventCallback : IRequestCallback
     {
         void onSuccess(int id, JSONObject payload)
         {
-            outputTextField->appendText(wstring(L"Successful custom event response: ") + String(payload.stringify()).wstr());
+            outputTextField->setText(wstring(L"Successful custom event response: ") + String(payload.stringify()).wstr());
             done();
         }
 
         void onStatus(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch custom event status: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch custom event status: ") + String(message).wstr());
         }
 
         void onError(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch custom event error: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch custom event error: ") + String(message).wstr());
             done();
         }
 
@@ -353,18 +353,18 @@ BranchOperations::getShortURL()
 
         void onSuccess(int id, JSONObject payload)
         {
-            outputTextField->appendText(wstring(L"Successfully generated URL: ") + String(payload.stringify()).wstr());
+            outputTextField->setText(wstring(L"Successfully generated URL: ") + String(payload.stringify()).wstr());
             done();
         }
 
         void onStatus(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Status getting URL: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Status getting URL: ") + String(message).wstr());
         }
 
         void onError(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Error getting URL: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Error getting URL: ") + String(message).wstr());
             done();
         }
 
@@ -377,31 +377,31 @@ BranchOperations::getShortURL()
 
     // TODO: Find a better place for this page.
     LinkRequest* request = new LinkRequest(L"https://jdee.github.io/example-win32.html");
-    outputTextField->appendText(wstring(L"Getting URL: ") + String(request->toString()).wstr());
+    outputTextField->setText(wstring(L"Getting URL: ") + String(request->toString()).wstr());
     request->send(branch);
 }
 
 void
 BranchOperations::closeSession()
 {
-    outputTextField->appendText(L"Closing session");
+    outputTextField->setText(L"Closing session");
 
     struct CloseCallback : IRequestCallback
     {
         void onSuccess(int id, JSONObject payload)
         {
-            outputTextField->appendText(wstring(L"Successful close response: ") + String(payload.stringify()).wstr());
+            outputTextField->setText(wstring(L"Successful close response: ") + String(payload.stringify()).wstr());
             done();
         }
 
         void onStatus(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch close status: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch close status: ") + String(message).wstr());
         }
 
         void onError(int id, int code, string message)
         {
-            outputTextField->appendText(wstring(L"Branch close error: ") + String(message).wstr());
+            outputTextField->setText(wstring(L"Branch close error: ") + String(message).wstr());
             done();
         }
     private:
@@ -428,7 +428,7 @@ BranchOperations::toggleTracking()
     if (isDisabled)
     {
         branch->getAdvertiserInfo().enableTracking();
-        outputTextField->appendText(L"Tracking enabled");
+        outputTextField->setText(L"Tracking enabled");
         // It's necessary to send a new /v1/open after enabling tracking to obtain
         // a fresh session_id, or subsequent calls fail. This can be rolled into the
         // SDK. This is what the Web SDK does, e.g.
@@ -437,7 +437,7 @@ BranchOperations::toggleTracking()
     else
     {
         branch->getAdvertiserInfo().disableTracking();
-        outputTextField->appendText(L"Tracking disabled");
+        outputTextField->setText(L"Tracking disabled");
     }
 }
 

--- a/BranchSDK-Samples/Windows/TestBed/TestBed.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/TestBed.cpp
@@ -191,14 +191,14 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
    getIdentityButton.setButtonPressCallback([]() {
        wstring identity = BranchOperations::getIdentity();
        if (identity.empty()) {
-           outputTextField.appendText(L"No developer identity is set.");
+           outputTextField.setText(L"No developer identity is set.");
        }
        else {
-           outputTextField.appendText(wstring(L"Developer identity is \"") + identity + L"\"");
+           outputTextField.setText(wstring(L"Developer identity is \"") + identity + L"\"");
        }
    });
    showSessionButton.setButtonPressCallback([]() {
-       outputTextField.appendText(BranchOperations::getSessionInfo());
+       outputTextField.setText(BranchOperations::getSessionInfo());
    });
 
    BranchOperations::showInitializationMessage();


### PR DESCRIPTION
There are two changes here.

One is basically a global search and replace in the app to replace `appendText` with `setText`. The output panel will only show the last response. A better option is to improve TestBed along the lines of https://cdn.branch.io/example.html, e.g. separate panels for current request and response. For now, this allows integration tests to pass and is an improvement in terms of readability.

The other change is to call `Branch::openSession` immediately after tracking is reenabled. This is necessary to create a new session without tracking disabled. This is also similar to the Web SDK (https://github.com/BranchMetrics/web-branch-deep-linking-attribution/blob/master/src/6_branch.js#L2376). This change should be included in the SDK in the next release. That will be a separate PR. For now, this requirement is documented. https://help.branch.io/developers-hub/docs/windows-cpp-advanced-features#enable-or-disable-user-tracking