### PR TITLE
Version bump script

### DIFF
--- a/BranchSDK-Samples/Windows/TestBed-Basic/TestBed-Basic-Package/Product.wxs
+++ b/BranchSDK-Samples/Windows/TestBed-Basic/TestBed-Basic-Package/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="Branch TestBed (Basic)" Language="1033" Version="1.2.1" Manufacturer="Branch Metrics, Inc." UpgradeCode="f66f62db-fbea-4c26-b0e3-ab91241a71da">
+  <Product Id="*" Name="Branch TestBed (Basic)" Language="1033" Version="1.2.2" Manufacturer="Branch Metrics, Inc." UpgradeCode="f66f62db-fbea-4c26-b0e3-ab91241a71da">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of TestBed (Basic) is already installed." />

--- a/BranchSDK-Samples/Windows/TestBed-Conan/TestBed-Conan-Package/Package.appxmanifest
+++ b/BranchSDK-Samples/Windows/TestBed-Conan/TestBed-Conan-Package/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="7dad590b-3b99-43f8-a027-fe84615ff35c"
     Publisher="CN=Branch Metrics, C=US"
-    Version="1.0.0.0" />
+    Version="1.2.2.0" />
 
   <Properties>
     <DisplayName>Branch TestBed (Conan)</DisplayName>

--- a/BranchSDK-Samples/Windows/TestBed-Local/TestBedLocalPackage/Package.appxmanifest
+++ b/BranchSDK-Samples/Windows/TestBed-Local/TestBedLocalPackage/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="144cb4b1-60b9-40ab-ad84-b335d5d28d05"
     Publisher="CN=Branch Metrics, C=US"
-    Version="1.2.1.0" />
+    Version="1.2.2.0" />
 
   <Properties>
     <DisplayName>Branch TestBed (Local)</DisplayName>

--- a/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/BranchOperations.cpp
@@ -359,6 +359,25 @@ BranchOperations::getShortURL()
 }
 
 void
+BranchOperations::getLongURL()
+{
+    struct LongLinkRequest : LinkInfo
+    {
+        LongLinkRequest(const std::wstring& canonicalUrl)
+        {
+            setFeature(L"testing");
+            addControlParameter(L"$canonical_url", canonicalUrl);
+            addControlParameter(L"$desktop_url", canonicalUrl);
+            addControlParameter(L"$desktop_web_open_delay_ms", "3000");
+        }
+    };
+
+    LongLinkRequest request(L"https://jdee.github.io/example-win32.html");
+    String longURL = request.createLongUrl(branch);
+    outputTextField->setText(wstring(L"Created long URL: ") + longURL.wstr());
+}
+
+void
 BranchOperations::closeSession()
 {
     outputTextField->setText(L"Closing session");

--- a/BranchSDK-Samples/Windows/TestBed/BranchOperations.h
+++ b/BranchSDK-Samples/Windows/TestBed/BranchOperations.h
@@ -24,6 +24,7 @@ struct BranchOperations
 	static void logStandardEvent();
 	static void logCustomEvent();
 	static void getShortURL();
+	static void getLongURL();
 	static void shutDownBranch();
 	static void showInitializationMessage();
 	static std::wstring getTrackingButtonLabel();

--- a/BranchSDK-Samples/Windows/TestBed/TestBed.cpp
+++ b/BranchSDK-Samples/Windows/TestBed/TestBed.cpp
@@ -41,16 +41,19 @@ static int const ID_GET_SHORT_URL_BUTTON = 1006;
 static int const ID_TRACKING_BUTTON = 1008;
 static int const ID_GET_IDENTITY_BUTTON = 1009;
 static int const ID_SHOW_SESSION_BUTTON = 1010;
+static int const ID_GET_LONG_URL_BUTTON = 1011;
 
 TextField outputTextField(L"Initializing...", 440, 20, 400, 400, ID_TEXT_FIELD);
 Button loginButton(L"Login", 20, 20, 190, 50, ID_LOGIN_BUTTON);
 Button logoutButton(L"Logout", 20, 90, 190, 50, ID_LOGOUT_BUTTON);
+Button trackingButton(L"Disable Tracking", 20, 230, 190, 50, ID_TRACKING_BUTTON);
+Button getIdentityButton(L"Get Identity", 20, 160, 190, 50, ID_GET_IDENTITY_BUTTON);
+
 Button standardEventButton(L"Standard Event", 230, 20, 190, 50, ID_STANDARD_EVENT_BUTTON);
 Button customEventButton(L"Custom Event", 230, 90, 190, 50, ID_CUSTOM_EVENT_BUTTON);
 Button getShortURLButton(L"Get Short URL", 230, 160, 190, 50, ID_GET_SHORT_URL_BUTTON);
-Button trackingButton(L"Disable Tracking", 20, 230, 190, 50, ID_TRACKING_BUTTON);
-Button getIdentityButton(L"Get Identity", 20, 160, 190, 50, ID_GET_IDENTITY_BUTTON);
-Button showSessionButton(L"Show Session", 230, 230, 190, 50, ID_SHOW_SESSION_BUTTON);
+Button getLongURLButton(L"Get Long URL", 230, 230, 190, 50, ID_GET_LONG_URL_BUTTON);
+Button showSessionButton(L"Show Session", 230, 300, 190, 50, ID_SHOW_SESSION_BUTTON);
 
 // Forward declarations of functions included in this code module:
 ATOM                MyRegisterClass(HINSTANCE hInstance);
@@ -171,6 +174,7 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
    standardEventButton.create(hWnd);
    customEventButton.create(hWnd);
    getShortURLButton.create(hWnd);
+   getLongURLButton.create(hWnd);
    trackingButton.create(hWnd);
    getIdentityButton.create(hWnd);
    showSessionButton.create(hWnd);
@@ -184,6 +188,7 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
    standardEventButton.setButtonPressCallback(BranchOperations::logStandardEvent);
    customEventButton.setButtonPressCallback(BranchOperations::logCustomEvent);
    getShortURLButton.setButtonPressCallback(BranchOperations::getShortURL);
+   getLongURLButton.setButtonPressCallback(BranchOperations::getLongURL);
    trackingButton.setButtonPressCallback([]() {
        BranchOperations::toggleTracking();
        trackingButton.setText(BranchOperations::getTrackingButtonLabel());
@@ -250,6 +255,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                 break;
             case ID_GET_SHORT_URL_BUTTON:
                 getShortURLButton.onPress();
+                break;
+            case ID_GET_LONG_URL_BUTTON:
+                getLongURLButton.onPress();
                 break;
             case ID_TRACKING_BUTTON:
                 trackingButton.onPress();

--- a/BranchSDK-Samples/Windows/TestBed/TestBedPackage/Package.appxmanifest
+++ b/BranchSDK-Samples/Windows/TestBed/TestBedPackage/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="be454d8c-d9d9-4afc-afe2-32941f166d5b"
     Publisher="CN=Branch Metrics, C=US"
-    Version="1.2.1.0" />
+    Version="1.2.2.0" />
 
   <Properties>
     <DisplayName>Branch TestBed</DisplayName>

--- a/BranchSDK/Windows/BranchInstaller/Product.wxs
+++ b/BranchSDK/Windows/BranchInstaller/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Language="1033" Manufacturer="Branch Metrics, Inc." Name="Branch C++ SDK for Windows" UpgradeCode="29b1dc08-2190-48f0-bc3c-7455381f2156" Version="1.2.1">
+  <Product Id="*" Language="1033" Manufacturer="Branch Metrics, Inc." Name="Branch C++ SDK for Windows" UpgradeCode="29b1dc08-2190-48f0-bc3c-7455381f2156" Version="1.2.2">
     <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200"/>
     <MajorUpgrade DowngradeErrorMessage="A newer version of Branch C++ SDK for Windows is already installed."/>
     <Media Cabinet="cab1.cab" EmbedCab="yes" Id="1"/>

--- a/BranchSDK/src/BranchIO/Version.h
+++ b/BranchSDK/src/BranchIO/Version.h
@@ -5,6 +5,6 @@
 
 #define BRANCHIO_VERSION_MAJOR               1
 #define BRANCHIO_VERSION_MINOR               2
-#define BRANCHIO_VERSION_REVISION            1
+#define BRANCHIO_VERSION_REVISION            2
 
 #endif  // BRANCHIO_VERSION_H__

--- a/BranchSDK/tools/version_bump.py
+++ b/BranchSDK/tools/version_bump.py
@@ -67,4 +67,4 @@ update_file("../../BranchSDK-Samples/Windows/TestBed-Conan/TestBed-Conan-Package
 
 # Now commit
 
-# os.system('git commit -a -m"Version bump to ' + full_version + '"')
+os.system('git commit -a -m"Version bump to ' + full_version + '"')

--- a/BranchSDK/tools/version_bump.py
+++ b/BranchSDK/tools/version_bump.py
@@ -1,3 +1,8 @@
+# Usage:
+# python version_bump.py 1.2.2
+#
+# The version number is required and never inferred. Suffixes such as -beta.1 are supported.
+
 import os, re, sys
 
 # Substitutes replacement for \2 in any match
@@ -36,30 +41,30 @@ version_components = reduced_version.split(".")
 print("Bumping to " + full_version)
 
 # conan package version
-update_file("../../conanfile.py", r'^(\s*version\s*=\s*")(.*)(")', full_version)
+update_file("../../conanfile.py", r'^(\s*version\s*=\s*")(.*)(")$', full_version)
 
 # version in CMakeLists.txt
-update_file("../../CMakeLists.txt", r'^(\s*project\(root\s+VERSION\s+)(\d+\.\d+\.\d+)(.*)', reduced_version)
+update_file("../../CMakeLists.txt", r'^(\s*project\(root\s+VERSION\s+)(\d+\.\d+\.\d+)(.*)$', reduced_version)
 
 # version in MSI package
-update_file("../Windows/BranchInstaller/Product.wxs", r'(<Product.*Version=")(\d+\.\d+\.\d+)(")', reduced_version)
+update_file("../Windows/BranchInstaller/Product.wxs", r'^(\s*<Product.*Version=")(\d+\.\d+\.\d+)(".*)$', reduced_version)
 
 # version components in Version.h
-update_file("../src/BranchIO/Version.h", r'(BRANCHIO_VERSION_MAJOR\s+)(\d+)(.*)', version_components[0])
-update_file("../src/BranchIO/Version.h", r'(BRANCHIO_VERSION_MINOR\s+)(\d+)(.*)', version_components[1])
-update_file("../src/BranchIO/Version.h", r'(BRANCHIO_VERSION_REVISION\s+)(\d+)(.*)', version_components[2])
+update_file("../src/BranchIO/Version.h", r'^(.*BRANCHIO_VERSION_MAJOR\s+)(\d+)(.*)$', version_components[0])
+update_file("../src/BranchIO/Version.h", r'^(.*BRANCHIO_VERSION_MINOR\s+)(\d+)(.*)$', version_components[1])
+update_file("../src/BranchIO/Version.h", r'^(.*BRANCHIO_VERSION_REVISION\s+)(\d+)(.*)$', version_components[2])
 
 # versions in example app packaging
 # TestBed-Basic uses Wix
-update_file("../../BranchSDK-Samples/Windows/TestBed-Basic/TestBed-Basic-Package/Product.wxs", r'(<Product.*Version=")(\d+\.\d+\.\d+)(")', reduced_version)
+update_file("../../BranchSDK-Samples/Windows/TestBed-Basic/TestBed-Basic-Package/Product.wxs", r'^(\s*<Product.*Version=")(\d+\.\d+\.\d+)(".*)$', reduced_version)
 
 # The rest use MSIX (4-part version with .0 at the end)
-update_file("../../BranchSDK-Samples/Windows/TestBed/TestBedPackage/Package.appxmanifest", r'^(\s*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
-update_file("../../BranchSDK-Samples/Windows/TestBed-Local/TestBedLocalPackage/Package.appxmanifest", r'^(\s*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
-update_file("../../BranchSDK-Samples/Windows/TestBed-Conan/TestBed-Conan-Package/Package.appxmanifest", r'^(\s*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
+update_file("../../BranchSDK-Samples/Windows/TestBed/TestBedPackage/Package.appxmanifest", r'^(\s*Version=")(\d+\.\d+\.\d+)(\.0".*)$', reduced_version)
+update_file("../../BranchSDK-Samples/Windows/TestBed-Local/TestBedLocalPackage/Package.appxmanifest", r'^(\s*Version=")(\d+\.\d+\.\d+)(\.0".*)$', reduced_version)
+update_file("../../BranchSDK-Samples/Windows/TestBed-Conan/TestBed-Conan-Package/Package.appxmanifest", r'^(\s*Version=")(\d+\.\d+\.\d+)(\.0".*)$', reduced_version)
 
 # TODO: Update binary .rc file in each app with version number that appears in the About dialog.
 
 # Now commit
 
-os.system('git commit -a -m"Version bump to ' + full_version + '"')
+# os.system('git commit -a -m"Version bump to ' + full_version + '"')

--- a/BranchSDK/tools/version_bump.py
+++ b/BranchSDK/tools/version_bump.py
@@ -35,10 +35,27 @@ version_components = reduced_version.split(".")
 
 print("Bumping to " + full_version)
 
+# conan package version
 update_file("../../conanfile.py", r'^(\s*version\s*=\s*")(.*)(")', full_version)
+
+# version in CMakeLists.txt
 update_file("../../CMakeLists.txt", r'^(\s*project\(root\s+VERSION\s+)(\d+\.\d+\.\d+)(.*)', reduced_version)
+
+# version in MSI package
 update_file("../Windows/BranchInstaller/Product.wxs", r'(<Product.*Version=")(\d+\.\d+\.\d+)(")', reduced_version)
 
+# version components in Version.h
 update_file("../src/BranchIO/Version.h", r'(BRANCHIO_VERSION_MAJOR\s+)(\d+)(.*)', version_components[0])
 update_file("../src/BranchIO/Version.h", r'(BRANCHIO_VERSION_MINOR\s+)(\d+)(.*)', version_components[1])
 update_file("../src/BranchIO/Version.h", r'(BRANCHIO_VERSION_REVISION\s+)(\d+)(.*)', version_components[2])
+
+# versions in example app packaging
+# TestBed-Basic uses Wix
+update_file("../../BranchSDK-Samples/Windows/TestBed-Basic/TestBed-Basic-Package/Product.wxs", r'(<Product.*Version=")(\d+\.\d+\.\d+)(")', reduced_version)
+
+# The rest use MSIX (4-part version with .0 at the end)
+update_file("../../BranchSDK-Samples/Windows/TestBed-Local/TestBedLocalPackage/Package.appxmanifest", r'(<Identity.*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
+update_file("../../BranchSDK-Samples/Windows/TestBed/TestBedPackage/Package.appxmanifest", r'(<Identity.*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
+update_file("../../BranchSDK-Samples/Windows/TestBed-Conan/TestBed-Conan-Package/Package.appxmanifest", r'(<Identity.*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
+
+# TODO: Update binary .rc file in each app with version number that appears in the About dialog.

--- a/BranchSDK/tools/version_bump.py
+++ b/BranchSDK/tools/version_bump.py
@@ -54,9 +54,9 @@ update_file("../src/BranchIO/Version.h", r'(BRANCHIO_VERSION_REVISION\s+)(\d+)(.
 update_file("../../BranchSDK-Samples/Windows/TestBed-Basic/TestBed-Basic-Package/Product.wxs", r'(<Product.*Version=")(\d+\.\d+\.\d+)(")', reduced_version)
 
 # The rest use MSIX (4-part version with .0 at the end)
-update_file("../../BranchSDK-Samples/Windows/TestBed-Local/TestBedLocalPackage/Package.appxmanifest", r'(<Identity.*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
-update_file("../../BranchSDK-Samples/Windows/TestBed/TestBedPackage/Package.appxmanifest", r'(<Identity.*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
-update_file("../../BranchSDK-Samples/Windows/TestBed-Conan/TestBed-Conan-Package/Package.appxmanifest", r'(<Identity.*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
+update_file("../../BranchSDK-Samples/Windows/TestBed/TestBedPackage/Package.appxmanifest", r'^(\s*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
+update_file("../../BranchSDK-Samples/Windows/TestBed-Local/TestBedLocalPackage/Package.appxmanifest", r'^(\s*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
+update_file("../../BranchSDK-Samples/Windows/TestBed-Conan/TestBed-Conan-Package/Package.appxmanifest", r'^(\s*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
 
 # TODO: Update binary .rc file in each app with version number that appears in the About dialog.
 

--- a/BranchSDK/tools/version_bump.py
+++ b/BranchSDK/tools/version_bump.py
@@ -1,4 +1,4 @@
-import re, sys
+import os, re, sys
 
 # Substitutes replacement for \2 in any match
 def update_file(path, regex, replacement):
@@ -59,3 +59,7 @@ update_file("../../BranchSDK-Samples/Windows/TestBed/TestBedPackage/Package.appx
 update_file("../../BranchSDK-Samples/Windows/TestBed-Conan/TestBed-Conan-Package/Package.appxmanifest", r'(<Identity.*Version=")(\d+\.\d+\.\d+)(\.0)', reduced_version)
 
 # TODO: Update binary .rc file in each app with version number that appears in the About dialog.
+
+# Now commit
+
+os.system('git commit -a -m"Version bump to ' + full_version + '"')

--- a/BranchSDK/tools/version_bump.py
+++ b/BranchSDK/tools/version_bump.py
@@ -31,9 +31,14 @@ if not match:
 # Now reduced_version is all digits. full_version may have a suffix.
 reduced_version = match.group(0)
 
+version_components = reduced_version.split(".")
+
 print("Bumping to " + full_version)
 
 update_file("../../conanfile.py", r'^(\s*version\s*=\s*")(.*)(")', full_version)
 update_file("../../CMakeLists.txt", r'^(\s*project\(root\s+VERSION\s+)(\d+\.\d+\.\d+)(.*)', reduced_version)
-# BranchSDK/src/BranchIO/Version.h => reduced_version, split
-# BranchSDK/Windows/BranchInstaller/Product.wxs => reduced_version
+update_file("../Windows/BranchInstaller/Product.wxs", r'(<Product.*Version=")(\d+\.\d+\.\d+)(")', reduced_version)
+
+update_file("../src/BranchIO/Version.h", r'(BRANCHIO_VERSION_MAJOR\s+)(\d+)(.*)', version_components[0])
+update_file("../src/BranchIO/Version.h", r'(BRANCHIO_VERSION_MINOR\s+)(\d+)(.*)', version_components[1])
+update_file("../src/BranchIO/Version.h", r'(BRANCHIO_VERSION_REVISION\s+)(\d+)(.*)', version_components[2])

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(root VERSION 1.2.1 LANGUAGES CXX)
+project(root VERSION 1.2.2 LANGUAGES CXX)
 
 # Determines handling of RPATH and related variables when building dylibs on Mac.
 # TODO(jdee): Review this. RPATH is an issue on Unix right now.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
 
-# TODO(jdee): Set the version in one place and pass it around.
 project(root VERSION 1.2.1 LANGUAGES CXX)
 
 # Determines handling of RPATH and related variables when building dylibs on Mac.

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,6 @@ class BranchioConan(ConanFile):
 
     # ----- Package metadata -----
     name = "BranchIO"
-    # TODO(jdee): Set the version in one place and propagate it
     version = "1.2.1"
     license = "MIT"
     description = "Branch Metrics deep linking and attribution analytics C++ SDK"

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ class BranchioConan(ConanFile):
 
     # ----- Package metadata -----
     name = "BranchIO"
-    version = "1.2.1"
+    version = "1.2.2"
     license = "MIT"
     description = "Branch Metrics deep linking and attribution analytics C++ SDK"
     topics = (


### PR DESCRIPTION
Finished off the incomplete version_bump.py script under BranchSDK/tools. Most of this could be done with cmake templates (e.g. BranchSDK/src/BranchIO/Version.h.in), but we'd like to move away from cmake, and the concrete conanfile.py must be checked into the repo, not just a template. This is a flexible approach. It doesn't handle the versions that show up the About dialog for each example app, defined in binary .rc files. It may be best just to remove the versions there so incorrect versions don't show up.

@BranchMetrics/core-team 