### PR TITLE
[INTENG-12752] long url fix

### DIFF
--- a/BranchSDK/src/BranchIO/LinkInfo.cpp
+++ b/BranchSDK/src/BranchIO/LinkInfo.cpp
@@ -265,14 +265,15 @@ LinkInfo::createLongUrl(Branch* branchInstance, const String& baseUrl) const {
         uri.addQueryParameter(JSONKEY_CAMPAIGN, campaign);
     }
 
-    // Take the controlParams, convert those to a string, and base64 them
-    // Note that Poco Base64 introduces by default line endings after 74?? characters.  Call setLineLength(0) to fix.
-    // Note further that Poco Base64 implementation appears to require an eol, or it doesn't complete the encoding.
     if (!_controlParams.isEmpty()) {
+        // https://gist.github.com/kidapu/0b9c2cbe98191a394c80
+        // Base64-encode control params as data query param
         stringstream ss;
+        ss.str("");
         Poco::Base64Encoder b64enc(ss);
         b64enc.rdbuf()->setLineLength(0);
-        b64enc << _controlParams.toString() << std::endl;
+        b64enc << _controlParams.toString();
+        b64enc.close();
 
         uri.addQueryParameter(JSONKEY_DATA, ss.str());
     }

--- a/BranchSDK/test/LinkInfoTest.cpp
+++ b/BranchSDK/test/LinkInfoTest.cpp
@@ -6,7 +6,9 @@
 
 #include <BranchIO/LinkInfo.h>
 #include <BranchIO/Event/Event.h>
+#include <Poco/Base64Decoder.h>
 #include <Poco/Base64Encoder.h>
+#include <Poco/URI.h>
 
 #include "ResponseCounter.h"
 #include "MockClientSession.h"
@@ -17,6 +19,7 @@ using namespace BranchIO;
 using namespace BranchIO::Test;
 using namespace std;
 using namespace testing;
+using namespace Poco;
 
 class LinkInfoTest : public ::testing::Test {
 protected:
@@ -139,4 +142,36 @@ TEST_F(LinkInfoTest, FallbackToLongUrl) {
     EXPECT_CALL(callback, onSuccess(_, _)).Times(1);
 
     info.createUrl(mBranch, &callback);
+}
+
+TEST_F(LinkInfoTest, LongUrlData) {
+    LinkInfo info;
+    info.addControlParameter("$desktop_web_open_delay_ms", "3000");
+    string sUrl = info.createLongUrl(mBranch);
+
+    // Now parse the generated URL string
+    URI url(sUrl);
+    URI::QueryParameters params(url.getQueryParameters());
+
+    string data;
+    for (auto it=params.begin(); it!=params.end(); ++it) {
+        if (it->first != "data") continue;
+        data = it->second;
+        break;
+    }
+
+    // There should be a data query parameter
+    ASSERT_FALSE(data.empty());
+
+    stringstream ss(data);
+    Base64Decoder decoder(ss);
+
+    string decodedData;
+    decoder >> decodedData;
+
+    // The data parameter should be successfully decoded as base64
+    ASSERT_FALSE(decodedData.empty());
+
+    // The decoded data parameter should be a valid JSON object
+    ASSERT_NO_THROW(JSONObject::parse(decodedData));
 }

--- a/BranchSDK/test/LinkInfoTest.cpp
+++ b/BranchSDK/test/LinkInfoTest.cpp
@@ -173,5 +173,9 @@ TEST_F(LinkInfoTest, LongUrlData) {
     ASSERT_FALSE(decodedData.empty());
 
     // The decoded data parameter should be a valid JSON object
-    ASSERT_NO_THROW(JSONObject::parse(decodedData));
+    auto parsedObject = JSONObject::parse(decodedData);
+
+    // The control parameter added above should be there
+    string delayParam = parsedObject.get("$desktop_web_open_delay_ms").extract<string>();
+    ASSERT_EQ("3000", delayParam);
 }


### PR DESCRIPTION
This corrects the base64-encoding of control parameters using `Poco::Base64Encoder`. The key is to call `.close()` on the encoder once all data have been appended, as in the example in the gist in a comment.

There was a unit test for long URL creation, but it didn't use control parameters and didn't validate the data parameter. A test has been added for this. This test fails before the second commit and passes afterward.

TestBed-Local now generates valid long links like https://bnc.lt/a/key_live_og1djX2V7XDJ7bWkeGnD5enbxAiq4hcG?feature=testing&data=eyIkY2Fub25pY2FsX3VybCI6Imh0dHBzOlwvXC9qZGVlLmdpdGh1Yi5pb1wvZXhhbXBsZS13aW4zMi5odG1sIiwiJGRlc2t0b3BfdXJsIjoiaHR0cHM6XC9cL2pkZWUuZ2l0aHViLmlvXC9leGFtcGxlLXdpbjMyLmh0bWwiLCIkZGVza3RvcF93ZWJfb3Blbl9kZWxheV9tcyI6IjMwMDAifQ%3D%3D

@BranchMetrics/core-team 