### PR TITLE
[SDK-1129] Remove all #ifdef WIN32 used to distinguish Windows from Unix

### DIFF
--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -17,16 +17,10 @@ using namespace std;
 #include "BranchIO/Version.h"
 #include "BranchIO/Util/RequestManager.h"
 
-// Create a string that looks like this:  "Branch Windows SDK v1.2.3"
-#define STRINGIZE2(s) #s
-#define STRINGIZE(s) STRINGIZE2(s)
-#define VER_FILE_VERSION_STR        STRINGIZE(BRANCHIO_VERSION_MAJOR)        \
-                                    "." STRINGIZE(BRANCHIO_VERSION_MINOR)    \
-                                    "." STRINGIZE(BRANCHIO_VERSION_REVISION)
-
-#define VER_FILE_VERSION_DISPLAY    "Branch "                       \
-                                    VERSION_PLATFORM  " SDK v"      \
-                                    VER_FILE_VERSION_STR
+#define _string_of(x) #x
+#define _version(maj, min, rev) _string_of(maj) "." _string_of(min) "." _string_of(rev)
+#define VER_FILE_VERSION_STR _version(BRANCHIO_VERSION_MAJOR, BRANCHIO_VERSION_MINOR, BRANCHIO_VERSION_REVISION)
+#define VER_FILE_VERSION_DISPLAY "Branch Win32 SDK v" VER_FILE_VERSION_STR
 
 namespace BranchIO {
 
@@ -335,7 +329,8 @@ Branch::getBranchKey() const {
 }
 
 string Branch::getVersion() {
-    return VER_FILE_VERSION_STR;
+    static const char* const version = VER_FILE_VERSION_STR;
+    return version;
 }
 
 wstring Branch::getVersionW() {

--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -329,8 +329,7 @@ Branch::getBranchKey() const {
 }
 
 string Branch::getVersion() {
-    static const char* const version = VER_FILE_VERSION_STR;
-    return version;
+    return VER_FILE_VERSION_STR;
 }
 
 wstring Branch::getVersionW() {

--- a/BranchSDK/src/BranchIO/Branch.cpp
+++ b/BranchSDK/src/BranchIO/Branch.cpp
@@ -30,23 +30,11 @@ using namespace std;
 
 namespace BranchIO {
 
-#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
-#define VERSION_PLATFORM  "Unix"
-class BranchUnix : public Branch {
- public:
-    BranchUnix() : Branch() {}
-    virtual ~BranchUnix() {}
-};
-
-#elif defined(_WIN64) || defined(_WIN32)
-#define VERSION_PLATFORM  "Windows"
 class BranchWindows : public Branch {
  public:
     BranchWindows() : Branch() {}
     virtual ~BranchWindows() {}
 };
-
-#endif
 
 using namespace std;
 
@@ -164,11 +152,7 @@ Branch *Branch::create(const String& branchKey, AppInfo* pInfo) {
 
     // Must initialize Branch object after prefix set.
     Branch* instance = nullptr;
-#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
-    instance = new BranchUnix();
-#elif defined(_WIN64) || defined(_WIN32)
     instance = new BranchWindows();
-#endif
 
     // Set these on the current app
     if (hasGlobalTrackingDisabled && !storage.has("advertiser.trackingDisabled")) {
@@ -293,12 +277,10 @@ Branch::getIdentity() {
     return Storage::instance().getString("session.identity");
 }
 
-#ifdef WIN32
 wstring
 Branch::getIdentityW() {
     return String(getIdentity()).wstr();
 }
-#endif  // WIN32
 
 void
 Branch::stop() {
@@ -356,8 +338,6 @@ string Branch::getVersion() {
     return VER_FILE_VERSION_STR;
 }
 
-#ifdef WIN32
-
 wstring Branch::getVersionW() {
     return String(getVersion()).wstr();
 }
@@ -365,7 +345,5 @@ wstring Branch::getVersionW() {
 wstring Branch::getBranchKeyW() const {
     return String(getBranchKey()).wstr();
 }
-
-#endif  // WIN32
 
 }  // namespace BranchIO

--- a/BranchSDK/src/BranchIO/Branch.h
+++ b/BranchSDK/src/BranchIO/Branch.h
@@ -85,7 +85,6 @@ class BRANCHIO_DLL_EXPORT Branch {
      */
     std::string getBranchKey() const;
 
-#ifdef WIN32
     /**
      * @return the SDK Version as a UTF-16 string
      */
@@ -95,7 +94,6 @@ class BRANCHIO_DLL_EXPORT Branch {
      * @return the Branch key as a UTF-16 string
      */
     std::wstring getBranchKeyW() const;
-#endif  // WIN32
 
     /**
      * From IPackagingInfo
@@ -146,13 +144,11 @@ class BRANCHIO_DLL_EXPORT Branch {
      */
     static std::string getIdentity();
 
-#ifdef WIN32
     /**
      * Get the current developer identity as a UTF-16 string
      * @return the current developer identity (blank if none)
      */
     static std::wstring getIdentityW();
-#endif  // WIN32
 
  private:
     /**

--- a/BranchSDK/src/BranchIO/String.h
+++ b/BranchSDK/src/BranchIO/String.h
@@ -3,13 +3,9 @@
 #ifndef BRANCHIO_STRING_H__
 #define BRANCHIO_STRING_H__
 
-#ifdef WIN32
 #include <Windows.h>
-#endif  // WIN32
 #include <string>
-#ifdef WIN32
 #include <vector>
-#endif  // WIN32
 
 namespace BranchIO {
 
@@ -43,7 +39,6 @@ class String {
      */
     std::string str() const { return m_string; }
 
-#ifdef WIN32
     /**
      * Conversion operator from std::wstring
      * @param ws a UTF-16 string
@@ -105,7 +100,6 @@ class String {
         // look for null termination
         return std::wstring(&buffer[0], &buffer[length]);
     }
-#endif  // WIN32
 
  private:
     std::string m_string;

--- a/BranchSDK/src/BranchIO/Util/Log.cpp
+++ b/BranchSDK/src/BranchIO/Util/Log.cpp
@@ -9,13 +9,8 @@
 #include <Poco/Thread.h>
 #include <Poco/Timestamp.h>
 
-#ifdef WIN32
 #include <Poco/EventLogChannel.h>
 #include <Poco/WindowsConsoleChannel.h>
-#else
-#include <Poco/ConsoleChannel.h>
-#include <Poco/SyslogChannel.h>
-#endif  // WIN32
 
 #include <Poco/FileChannel.h>
 
@@ -85,13 +80,8 @@ operator>>(std::istream& s, BranchIO::Log::Level& level) {
 
 namespace BranchIO {
 
-#ifdef WIN32
 typedef WindowsColorConsoleChannel ConsoleLoggingChannel;
 typedef EventLogChannel SystemLoggingChannel;
-#else
-typedef ColorConsoleChannel ConsoleLoggingChannel;
-typedef SyslogChannel SystemLoggingChannel;
-#endif  // WIN32
 
 Log&
 Log::instance() {
@@ -170,13 +160,7 @@ std::string
 Log::buildMessage(Level level, const std::string& message, const char* func, const char* file, int line) {
     string path(file ? file : "");
 
-    static const char* const separator(
-#ifdef WIN32
-        "\\"
-#else
-        "/"
-#endif  // WIN32
-    );  // NOLINT(whitespace/parens)
+    static const char* const separator("\\");
 
     // Just show the last path component
     string::size_type offset = path.find_last_of(separator);

--- a/BranchSDK/src/BranchIO/Util/Storage.h
+++ b/BranchSDK/src/BranchIO/Util/Storage.h
@@ -3,18 +3,12 @@
 #ifndef BRANCHIO_UTIL_STORAGE_H__
 #define BRANCHIO_UTIL_STORAGE_H__
 
-#ifdef WIN32
 #include "WindowsStorage.h"
-#else
-#include "UnixStorage.h"
-#endif  // WIN32
 
 namespace BranchIO {
-#ifdef WIN32
+
 typedef WindowsStorage Storage;
-#else
-typedef UnixStorage Storage;
-#endif  // WIN32
+
 }  // namespace BranchIO
 
 #endif  // BRANCHIO_UTIL_STORAGE_H__

--- a/BranchSDK/src/BranchIO/dll.h
+++ b/BranchSDK/src/BranchIO/dll.h
@@ -3,14 +3,13 @@
 #ifndef BRANCHIO_DLL_H__
 #define BRANCHIO_DLL_H__
 
-#ifdef WIN32
-    #ifdef BRANCHIO_BUILD_DLL
-        #define BRANCHIO_DLL_EXPORT __declspec(dllexport)
-    #endif  // BRANCHIO_BUILD_DLL
-    #ifdef BRANCHIO_DLL
-        #define BRANCHIO_DLL_EXPORT __declspec(dllimport)
-    #endif  // BRANCHIO_DLL
-#endif  // BRANCHIO_DLL
+#ifdef BRANCHIO_DLL
+#define BRANCHIO_DLL_EXPORT __declspec(dllimport)
+#endif  // BRANCHIO_DLL#endif  // BRANCHIO_DLL
+
+#ifdef BRANCHIO_BUILD_DLL
+    #define BRANCHIO_DLL_EXPORT __declspec(dllexport)
+#endif  // BRANCHIO_BUILD_DLL
 
 #ifndef BRANCHIO_DLL_EXPORT
 #define BRANCHIO_DLL_EXPORT


### PR DESCRIPTION
Removed all instances of `#ifdef WIN32` used to distinguish Windows from Unix. This SDK is Windows only.

@BranchMetrics/core-team 