### PR TITLE
Conanfile updates

### DIFF
--- a/.github/workflows/rmake.yml
+++ b/.github/workflows/rmake.yml
@@ -22,8 +22,7 @@ jobs:
       # Conan maintains its own cache in ~/.conan/data. Poco takes a long time to build from source. If
       # the version and options have not changed, Conan will not build Poco if it finds it in cache. It
       # will update the cache any time it needs to rebuild Poco. This should only happen when the
-      # conanfile.py changes.
-      # TODO: Review this assumption. Also ~/.conan also includes profiles and settings along with the cache.
+      # conanfile.py changes as long as the recipe pins to a specific version of Poco.
       - name: Restore Conan cache, profiles, settings
         uses: actions/cache@v2
         with:

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 import os, shutil
 
 class BranchioConan(ConanFile):
@@ -43,6 +44,10 @@ class BranchioConan(ConanFile):
     # packages, to avoid version drift.
     requires = "Poco/1.10.1@pocoproject/stable"
     build_requires = "gtest/1.8.1@bincrafters/stable"
+
+    def validate(self):
+        if self.settings.os != "Windows":
+            raise ConanInvalidConfiguration("Windows required")
 
     def build(self):
         library_type = "shared" if self.options.shared else "static"

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,6 @@ class BranchioConan(ConanFile):
     )
     author = "Branch Metrics, Inc <sdk-team@branch.io>"
     url = "https://github.com/BranchMetrics/cpp-branch-deep-linking-attribution"
-    # TODO(jdee): Might not want to call this windows-
     homepage = "https://help.branch.io/developers-hub/docs/windows-cpp-sdk-overview"
 
     # ----- Package settings and options -----
@@ -38,8 +37,11 @@ class BranchioConan(ConanFile):
     exports_sources = "BranchIO"
 
     # ----- Package dependencies -----
-    # Allow patch updates to Poco
-    requires = "Poco/[~=1.10.1]@pocoproject/stable"
+    # Pin to a specific version of Poco for stability of CI and other environments using
+    # Conan. Conan recently introduced lockfiles, which may be useful for this purpose
+    # as well. For now, this is consistent with transitive dependencies in Branch Maven
+    # packages, to avoid version drift.
+    requires = "Poco/1.10.1@pocoproject/stable"
     build_requires = "gtest/1.8.1@bincrafters/stable"
 
     def build(self):
@@ -70,7 +72,7 @@ class BranchioConan(ConanFile):
 
     def test(self):
         # TODO(jdee): This isn't necessarily the right idea. The idea is to use a project
-        # that imports this one to test that we've been installed correctly.
+        # that imports this one to test that we've been installed correctly, e.g. TestBed.
         CMake(self).test()
 
     def package(self):


### PR DESCRIPTION
Pinning to a specific version of Poco avoids version drift without lockfiles and stabilizes CI and any other environment using Poco. This can be revisited.

@BranchMetrics/core-team 