### PR TITLE
[SDK-2072] Create GHA to sync release notes with ReadMe Version History

### DIFF
--- a/.github/workflows/sync-readme-changelog.yml
+++ b/.github/workflows/sync-readme-changelog.yml
@@ -1,0 +1,96 @@
+name: Update Version History on Readme
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Format and publish release notes to version history doc
+      id: update
+      run: |
+        # Get release name, body, and date from the release event
+        release_name="${{ github.event.release.tag_name }}"
+        release_body="${{ github.event.release.body }}"
+        release_date=$(date -d "${{ github.event.release.published_at }}" +"%Y-%B-%d")
+        # Format release notes
+        formatted_notes="## v$release_name\n\n**($release_date)**\n\n$release_body"
+        
+        # Get existing version history page
+        existing_content=$(curl --request GET \
+            --url https://dash.readme.com/api/v1/docs/windows-cpp-version-history \
+            --header 'accept: application/json' \
+            --header "authorization: Basic ${{ secrets.readme_api_key_base64 }}" \
+            | jq -r '.body')
+    
+        # Prepend new release notes to existing content
+        new_content=$(echo -e "$formatted_notes\n\n$existing_content")
+        payload=$(jq -n --arg nc "$new_content" '{"body": $nc}')
+
+        # Update version history page with new release notes
+        curl --request PUT \
+            --url https://dash.readme.com/api/v1/docs/windows-cpp-version-history \
+            --header 'accept: application/json' \
+            --header "authorization: Basic ${{ secrets.readme_api_key_base64 }}" \
+            --header 'content-type: application/json' \
+            --data "$payload"
+
+    - name: Announce New Release in Slack
+      uses: slackapi/slack-github-action@v1.24.0
+      with:
+        channel-id: "CDFGXRM9S"
+        payload: |
+            {
+                "text": "New Release: Branch Windows SDK v${{ github.event.release.tag_name }}",
+                "blocks": [
+                    {
+                        "type": "header",
+                        "text": {
+                            "type": "plain_text",
+                            "text": ":rocket: New Release: Branch Windows SDK v${{ github.event.release.tag_name }}",                            
+                            "emoji": true
+                        }
+                    },
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ":star: *What's New*"
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ${{ toJSON(github.event.release.body) }}
+                        }
+                	},
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {
+                                "type": "button",
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": ":git: GitHub Release",
+                                    "emoji": true
+                                },
+                                "value": "github",
+                                "action_id": "github",
+                                "url": "${{ github.event.release.html_url }}"
+                            }
+                        ]
+                    }
+                ]
+            }
+    env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_SDK_BOT_TOKEN }}


### PR DESCRIPTION
## Reference
SDK-2072 -- Help Docs automate Readme changelogs

## Summary
<!-- Simple summary of what was changed. -->
Created a new Github Action that runs whenever a new Github Release is made. It uses the release tag and description to create a new section in the [public readme doc's version history page](https://help.branch.io/developers-hub/docs/windows-cpp-version-history). It also uses this data to send a Slack message in the SDK channel announcing the new release.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To streamline and speed up the release process even more while keeping out docs up to date.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
The action can be run locally using Act or a test release can be made to ensure everything works properly.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
