### PR TITLE
[SDK-2072] Automatically sync Readme docs version history page

### DIFF
--- a/.github/workflows/sync-readme-changelog.yml
+++ b/.github/workflows/sync-readme-changelog.yml
@@ -1,0 +1,98 @@
+name: Update Version History on ReadMe
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Format and publish release notes to version history doc
+      id: update
+      run: |
+        # Get release name, body, and date from the release event
+        release_name="${{ github.event.release.tag_name }}"
+        release_body="${{ github.event.release.body }}"
+        release_date=$(date -d "${{ github.event.release.published_at }}" +"%Y-%B-%d")
+
+        # Format release notes
+        formatted_notes="## v$release_name\n\n**($release_date)**\n\n$release_body"
+        
+        # Get existing version history page
+        existing_content=$(curl --request GET \
+            --url https://dash.readme.com/api/v1/docs/windows-cpp-version-history \
+            --header 'accept: application/json' \
+            --header "authorization: Basic ${{ secrets.readme_api_key_base64 }}" \
+            | jq -r '.body')
+    
+        # Prepend new release notes to existing content
+        new_content=$(echo -e "$formatted_notes\n\n$existing_content")
+        payload=$(jq -n --arg nc "$new_content" '{"body": $nc}')
+
+        # Update version history page with new release notes
+        curl --request PUT \
+            --url https://dash.readme.com/api/v1/docs/windows-cpp-version-history \
+            --header 'accept: application/json' \
+            --header "authorization: Basic ${{ secrets.readme_api_key_base64 }}" \
+            --header 'content-type: application/json' \
+            --data "$payload"
+
+    - name: Announce New Release in Slack
+      uses: slackapi/slack-github-action@v1.24.0
+      with:
+        channel-id: "C063MQJMKJN" #sdk-releases
+        payload: |
+            {
+                "text": "New Release: Branch Windows SDK v${{ github.event.release.tag_name }}",
+                "blocks": [
+                    {
+                        "type": "header",
+                        "text": {
+                            "type": "plain_text",
+                            "text": ":rocket: New Release: Branch Windows SDK v${{ github.event.release.tag_name }}",                            
+                            "emoji": true
+                        }
+                    },
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ":star: *What's New*"
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ${{ toJSON(github.event.release.body) }}
+                        }
+                	},
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {
+                                "type": "button",
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": ":git: GitHub Release",
+                                    "emoji": true
+                                },
+                                "value": "github",
+                                "action_id": "github",
+                                "url": "${{ github.event.release.html_url }}"
+                            }
+                        ]
+                    }
+                ]
+            }
+    env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_SDK_BOT_TOKEN }}
+          


### PR DESCRIPTION
## Reference
SDK-2072 -- Help Docs automate Readme changelogs

## Summary
Created a GitHub action that runs whenever a release is created. It takes the release name and description, then updates the public docs version history at https://help.branch.io/developers-hub/docs/windows-cpp-version-history.
Lastly, the action sends a slack message in the #sdk channel to broadcast the new release.

## Motivation
To streamline and speed up the release process even more while keeping out docs up to date.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.