### PR TITLE
[SDK-2190] Updated token for Stale GHA

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/stale@v5
       with:
-        repo-token: ${{ secrets.STALE_PERSONAL_ACCESS_TOKEN }}
+        repo-token: ${{ github.token }}
         days-before-issue-stale: 60
         days-before-close: 7
         stale-issue-message: 'This issue has been automatically marked as stale due to inactivity for 60 days. If this issue is still relevant, please respond with any updates or this issue will be closed in 7 days. If you believe this is a mistake, please comment to let us know. Thank you for your contributions.'


### PR DESCRIPTION
## Reference
SDK-2190 -- Fix Stale GitHub Action

## Description
The current repo-token provided does not have the proper permissions for commenting on and adding labels to issues. To fix this, we can provide the repo's github.token, which would be the default for this action.

## Testing Instructions
Run the GitHub action and observe if the result is successful. 

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.