### PR TITLE
[other] NO-TICKET: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BranchMetrics/data-platform
+* @BranchMetrics/saas-sdk-devs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BranchMetrics/data-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BranchMetrics/saas-sdk-devs
+* @BranchMetrics/sdk-maintainers


### PR DESCRIPTION
Assigns ownership via CODEOWNERS (* @BranchMetrics/data-platform) as part of the service-catalogue rollout.